### PR TITLE
Add ODH and RHOAI kustomize overlays

### DIFF
--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,0 +1,7 @@
+releases:
+  - name: Llama Stack
+    version: latest
+    repoUrl: https://github.com/opendatahub-io/llama-stack
+  - name: Open Data Hub Llama Stack Operator
+    version: latest
+    repoUrl: https://github.com/opendatahub-io/llama-stack-k8s-operator

--- a/config/overlays/odh/delete-namespace.yaml
+++ b/config/overlays/odh/delete-namespace.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opendatahub
+
+resources:
+  - ../../default
+
+patches:
+  # patch to remove default `system` namespace in ../../manager/manager.yaml
+  - path: delete-namespace.yaml
+
+configMapGenerator:
+  - name:  lls-parameters
+    behavior: merge
+    envs:
+      - params.env
+
+configurations:
+  - params.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: lls-parameters
+      version: v1
+      fieldPath: data.RELATED_IMAGE_ODH_LLAMASTACK_OPERATOR
+    targets:
+      - select:
+          kind: Deployment
+          name: controller-manager
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].image

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,0 +1,3 @@
+RELATED_IMAGE_ODH_LLAMASTACK_OPERATOR=quay.io/opendatahub/llama-stack-k8s-operator:latest
+OLLAMA_IMAGE=docker.io/llamastack/distribution-ollama:latest
+VLLM_IMAGE=docker.io/llamastack/distribution-remote-vllm:latest

--- a/config/overlays/odh/params.yaml
+++ b/config/overlays/odh/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+  - path: spec/template/spec/containers[]/image
+    kind: Deployment

--- a/config/overlays/rhoai/delete-namespace.yaml
+++ b/config/overlays/rhoai/delete-namespace.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system

--- a/config/overlays/rhoai/kustomization.yaml
+++ b/config/overlays/rhoai/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: redhat-ods-applications
+
+resources:
+  - ../../default
+
+patches:
+  # patch to remove default `system` namespace in ../../manager/manager.yaml
+  - path: delete-namespace.yaml
+
+configMapGenerator:
+  - name:  lls-parameters
+    behavior: merge
+    envs:
+      - params.env
+
+configurations:
+  - params.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: lls-parameters
+      version: v1
+      fieldPath: data.RELATED_IMAGE_ODH_LLAMASTACK_OPERATOR
+    targets:
+      - select:
+          kind: Deployment
+          name: controller-manager
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].image

--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -1,0 +1,3 @@
+RELATED_IMAGE_ODH_LLAMASTACK_OPERATOR=quay.io/opendatahub/llama-stack-k8s-operator:latest
+OLLAMA_IMAGE=docker.io/llamastack/distribution-ollama:latest
+VLLM_IMAGE=docker.io/llamastack/distribution-remote-vllm:latest

--- a/config/overlays/rhoai/params.yaml
+++ b/config/overlays/rhoai/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+  - path: spec/template/spec/containers[]/image
+    kind: Deployment


### PR DESCRIPTION
Add ODH / RHOAI specific kustomize manifests for installation by ODH Operator.

## Description
The manifests in this PR install `llama-stack-k8s-operator` into the `opendatahub` namespace for ODH and into the `redhat-ods-applications` namespace for RHOAI.

## How Has This Been Tested?
I've [extended the ODH operator](https://github.com/csams/opendatahub-operator/tree/add-llama-stack-k8s-operator) with a controller and tests for this operator and tested locally with crc and the following DSCI and DSC to ensure the operator deploys without errors.

DSCI:
```yaml
apiVersion: dscinitialization.opendatahub.io/v1
kind: DSCInitialization 
metadata:
  name: default-dsci
spec:
  applicationsNamespace: opendatahub
  monitoring:
    managementState: Removed
    namespace: redhat-ods-monitoring
  serviceMesh:
    managementState: Removed
  trustedCABundle:
    managementState: Managed
```

DSC:
```yaml
apiVersion: datasciencecluster.opendatahub.io/v1
kind: DataScienceCluster
metadata:
  name: default-dsc
spec:
  components:
    codeflare:
      managementState: Removed
    dashboard:
      managementState: Managed
    llamastackoperator:
      managementState: Managed
    datasciencepipelines:
      managementState: Removed
    kserve:
      managementState: Removed
      defaultDeploymentMode: RawDeployment
      serving:
        managementState: Removed 
        name: knative-serving
      nim:
        managementState: Removed
    kueue:
      managementState: Removed
    modelregistry:
      managementState: Removed
    modelmeshserving:
      managementState: Removed
    ray:
      managementState: Removed
    trainingoperator:
      managementState: Removed
    trustyai:
      managementState: Removed
    workbenches:
      managementState: Removed
```

## Merge criteria:
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
