### PR TITLE
update: change to use latest image than ODH

### DIFF
--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,3 +1,3 @@
-RELATED_IMAGE_ODH_LLAMASTACK_OPERATOR=quay.io/opendatahub/llama-stack-k8s-operator:odh
+RELATED_IMAGE_ODH_LLAMASTACK_OPERATOR=quay.io/opendatahub/llama-stack-k8s-operator:latest
 OPERATOR_VERSION=""
 LLAMA_STACK_VERSION=0.2.10


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- to use latest code from "odh" branch with the latest image from lls-o which is "latest" not "odh" from "odh" branch
https://github.com/opendatahub-io/llama-stack-k8s-operator/blob/ca0784bfac0dadee8b8ffa18a5ad84fc266b110e/.github/workflows/odh-build-image.yml#L33
- i understand the concern that tag "odh" was previously used as release image for ODH 2.30.0 and 2.31.0 so it is better to keep, not overwritten by new images built from "odh" branch



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the image tag for the LlamaStack Operator to use the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->