### PR TITLE
update(GH): change image tag

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -3,7 +3,7 @@ name: Tests Code Coverage
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [ main ]
+    branches: [ odh ]
 
 jobs:
   tests:

--- a/.github/workflows/main-build-image.yml
+++ b/.github/workflows/main-build-image.yml
@@ -29,4 +29,4 @@ jobs:
           password: ${{ secrets.APP_QUAY_TOKEN }}
 
       - name: Build and push latest image
-        run: make image-build image-push -e IMG=quay.io/llamastack/llama-stack-k8s-operator:latest
+        run: make image-build image-push -e IMG=quay.io/llamastack/llama-stack-k8s-operator:main

--- a/.github/workflows/odh-build-image.yml
+++ b/.github/workflows/odh-build-image.yml
@@ -3,7 +3,6 @@ name: Build Operator Image
 on:
   push:
     branches:
-       - main
        - odh
 
 permissions:

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,3 +1,3 @@
-RELATED_IMAGE_ODH_LLAMASTACK_OPERATOR=quay.io/opendatahub/llama-stack-k8s-operator:odh
+RELATED_IMAGE_ODH_LLAMASTACK_OPERATOR=quay.io/opendatahub/llama-stack-k8s-operator:latest
 OPERATOR_VERSION=""
 LLAMA_STACK_VERSION=0.2.10


### PR DESCRIPTION
- commit on odh branch, should build image with tag "latest" -- same as now
- commit on main branch, should build image with tag "main" -- change from latest to main
- code coverage should run on "odh" branch -- no need run code coverage on main since it is a sync branch

this is a follow up https://github.com/opendatahub-io/llama-stack-k8s-operator/pull/18


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflows to adjust which branches trigger code coverage and image build processes.
  * Changed image tags in build workflows and environment configuration for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->