### PR TITLE
[odh] Sync upstream + add 2.23 updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,6 @@ release: yq kustomize yamlfmt ## Prepare release files with VERSION and LLAMASTA
 	# Update environment variables in manager.yaml and format with our preferred YAML style
 	# using YQ because Kustomize doesn't support setting environment variables
 	$(call yq-fmt,'(select(.kind == "Deployment") | .spec.template.spec.containers[].env[] | select(.name == "OPERATOR_VERSION") | .value) = "$(VERSION)"',config/manager/manager.yaml)
-	$(call yq-fmt,'(select(.kind == "Deployment") | .spec.template.spec.containers[].env[] | select(.name == "LLAMA_STACK_VERSION") | .value) = "$(LLAMASTACK_VERSION)"',config/manager/manager.yaml)
 
 	# Generate manifests and build installer
 	$(MAKE) manifests generate

--- a/api/v1alpha1/llamastackdistribution_types.go
+++ b/api/v1alpha1/llamastackdistribution_types.go
@@ -160,8 +160,8 @@ const (
 type VersionInfo struct {
 	// OperatorVersion is the version of the operator managing this distribution
 	OperatorVersion string `json:"operatorVersion,omitempty"`
-	// DeploymentVersion is the version of the LlamaStack deployment
-	LlamaStackVersion string `json:"llamaStackServerVersion,omitempty"`
+	// LlamaStackServerVersion is the version of the LlamaStack server
+	LlamaStackServerVersion string `json:"llamaStackServerVersion,omitempty"`
 	// LastUpdated represents when the version information was last updated
 	LastUpdated metav1.Time `json:"lastUpdated,omitempty"`
 }

--- a/api/v1alpha1/llamastackdistribution_types.go
+++ b/api/v1alpha1/llamastackdistribution_types.go
@@ -39,7 +39,7 @@ const (
 	// DefaultLabelValue is the default value for labels
 	DefaultLabelValue = "llama-stack"
 	// DefaultMountPath is the default mount path for storage
-	DefaultMountPath = "/.llama"
+	DefaultMountPath = "/opt/app-root/src/.llama/distributions/rh/"
 	// LlamaStackDistributionKind is the kind name for LlamaStackDistribution resources
 	LlamaStackDistributionKind = "LlamaStackDistribution"
 )

--- a/config/crd/bases/llamastack.io_llamastackdistributions.yaml
+++ b/config/crd/bases/llamastack.io_llamastackdistributions.yaml
@@ -2155,8 +2155,8 @@ spec:
                     format: date-time
                     type: string
                   llamaStackServerVersion:
-                    description: DeploymentVersion is the version of the LlamaStack
-                      deployment
+                    description: LlamaStackServerVersion is the version of the LlamaStack
+                      server
                     type: string
                   operatorVersion:
                     description: OperatorVersion is the version of the operator managing

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,8 +41,6 @@ spec:
         env:
         - name: OPERATOR_VERSION
           value: "latest"
-        - name: LLAMA_STACK_VERSION
-          value: "latest"
         image: controller:latest
         name: manager
         securityContext:

--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -288,11 +288,11 @@ func (r *LlamaStackDistributionReconciler) createConfigMapFieldIndexer(ctx conte
 		r.configMapIndexFunc,
 	); err != nil {
 		// Log warning but don't fail startup - older Kubernetes versions may not support this
-		mgr.GetLogger().Info("Field indexer for ConfigMap references not supported, will use manual search fallback",
+		mgr.GetLogger().V(1).Info("Field indexer for ConfigMap references not supported, will use manual search fallback",
 			"error", err.Error())
 		return nil
 	}
-	mgr.GetLogger().Info("Successfully created field indexer for ConfigMap references - will use efficient lookups")
+	mgr.GetLogger().V(1).Info("Successfully created field indexer for ConfigMap references - will use efficient lookups")
 	return nil
 }
 
@@ -445,7 +445,7 @@ func (r *LlamaStackDistributionReconciler) isConfigMapReferenced(configMap clien
 	if err != nil {
 		// Field indexer failed (likely due to older Kubernetes version not supporting custom field labels)
 		// Fall back to a manual check instead of assuming all ConfigMaps are referenced
-		logger.Info("Field indexer not supported, falling back to manual ConfigMap reference check", "error", err.Error())
+		logger.V(1).Info("Field indexer not supported, falling back to manual ConfigMap reference check", "error", err.Error())
 		return r.manuallyCheckConfigMapReference(configMap)
 	}
 
@@ -519,7 +519,7 @@ func (r *LlamaStackDistributionReconciler) tryFieldIndexerLookup(ctx context.Con
 	attachedLlamaStacks := llamav1alpha1.LlamaStackDistributionList{}
 	err := r.List(ctx, &attachedLlamaStacks, client.MatchingFields{"spec.server.userConfig.configMapName": indexKey})
 	if err != nil {
-		logger.Info("Field indexer not supported, will fall back to a manual search for ConfigMap event processing",
+		logger.V(1).Info("Field indexer not supported, will fall back to a manual search for ConfigMap event processing",
 			"indexKey", indexKey, "error", err.Error())
 		return attachedLlamaStacks, false
 	}

--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -758,6 +758,44 @@ func (r *LlamaStackDistributionReconciler) getProviderInfo(ctx context.Context, 
 	return response.Data, nil
 }
 
+// getVersionInfo makes an HTTP request to the version endpoint.
+func (r *LlamaStackDistributionReconciler) getVersionInfo(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution) (string, error) {
+	u := r.getServerURL(instance, "/v1/version")
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create version request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to make version request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to query version endpoint: returned status code %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read version response: %w", err)
+	}
+
+	var response struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("failed to unmarshal version response: %w", err)
+	}
+
+	return response.Version, nil
+}
+
 // updateStatus refreshes the LlamaStack status.
 func (r *LlamaStackDistributionReconciler) updateStatus(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution, reconcileErr error) error {
 	// Initialize OperatorVersion if not set
@@ -826,9 +864,6 @@ func (r *LlamaStackDistributionReconciler) updateDeploymentStatus(ctx context.Co
 		instance.Status.Phase = llamav1alpha1.LlamaStackDistributionPhaseReady
 		deploymentReady = true
 		SetDeploymentReadyCondition(&instance.Status, true, MessageDeploymentReady)
-		if instance.Status.Version.LlamaStackVersion == "" {
-			instance.Status.Version.LlamaStackVersion = os.Getenv("LLAMA_STACK_VERSION")
-		}
 	}
 	instance.Status.AvailableReplicas = deployment.Status.ReadyReplicas
 	return deploymentReady, nil
@@ -903,6 +938,16 @@ func (r *LlamaStackDistributionReconciler) performHealthChecks(ctx context.Conte
 		instance.Status.DistributionConfig.Providers = nil
 	} else {
 		instance.Status.DistributionConfig.Providers = providers
+	}
+
+	// Get version information from the API endpoint
+	version, err := r.getVersionInfo(ctx, instance)
+	if err != nil {
+		logger.Error(err, "failed to get version info from API endpoint")
+		// Don't clear the version if we cant fetch it - keep the existing one
+	} else {
+		instance.Status.Version.LlamaStackServerVersion = version
+		logger.V(1).Info("Updated LlamaStack version from API endpoint", "version", version)
 	}
 }
 

--- a/controllers/resource_helper_test.go
+++ b/controllers/resource_helper_test.go
@@ -55,7 +55,7 @@ func TestBuildContainerSpec(t *testing.T) {
 					MountPath: llamav1alpha1.DefaultMountPath,
 				}},
 				Env: []corev1.EnvVar{
-					{Name: "HF_HOME", Value: "/.llama"},
+					{Name: "HF_HOME", Value: "/opt/app-root/src/.llama/distributions/rh/"},
 				},
 			},
 		},
@@ -129,7 +129,7 @@ func TestBuildContainerSpec(t *testing.T) {
 					MountPath: llamav1alpha1.DefaultMountPath,
 				}},
 				Env: []corev1.EnvVar{
-					{Name: "HF_HOME", Value: "/.llama"},
+					{Name: "HF_HOME", Value: "/opt/app-root/src/.llama/distributions/rh/"},
 				},
 			},
 		},

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -214,5 +214,5 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `operatorVersion` _string_ | OperatorVersion is the version of the operator managing this distribution |  |  |
-| `llamaStackServerVersion` _string_ | DeploymentVersion is the version of the LlamaStack deployment |  |  |
+| `llamaStackServerVersion` _string_ | LlamaStackServerVersion is the version of the LlamaStack server |  |  |
 | `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#time-v1-meta)_ | LastUpdated represents when the version information was last updated |  |  |

--- a/docs/odh/llama-stack-with-odh.md
+++ b/docs/odh/llama-stack-with-odh.md
@@ -115,6 +115,7 @@ spec:
       name: 'rh-dev'
     storage:
       size: 20Gi
+      mountPath: <custom-mount-path> ## Defaults to /opt/app-root/src/.llama/distributions/rh/
 ```
 
 ### 4. Verify LlamaStack Deployment

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
-		Development:     true,
+		Development:     false,
 		StacktraceLevel: zapcore.PanicLevel, // Set higher than ErrorLevel to avoid stack traces in logs
 	}
 	opts.BindFlags(flag.CommandLine)

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -2164,8 +2164,8 @@ spec:
                     format: date-time
                     type: string
                   llamaStackServerVersion:
-                    description: DeploymentVersion is the version of the LlamaStack
-                      deployment
+                    description: LlamaStackServerVersion is the version of the LlamaStack
+                      server
                     type: string
                   operatorVersion:
                     description: OperatorVersion is the version of the operator managing
@@ -2478,8 +2478,6 @@ spec:
         - /manager
         env:
         - name: OPERATOR_VERSION
-          value: latest
-        - name: LLAMA_STACK_VERSION
           value: latest
         image: quay.io/llamastack/llama-stack-k8s-operator:latest
         livenessProbe:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom mount path for storage in the LlamaStackDistribution resource.
  * Introduced an init container to set correct permissions on persistent storage when configured.

* **Improvements**
  * The LlamaStack server version is now fetched directly from the server and reflected in the status.
  * Enhanced logging with adjusted verbosity and switched to production-style log formatting.

* **Documentation**
  * Updated API and CRD documentation to clarify the meaning of the LlamaStack server version field.
  * Added usage example for custom storage mount paths.

* **Chores**
  * Removed unused environment variable for LlamaStack version from deployment configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->