### PR TITLE
fix: need latest image for overlays/rhoai

### DIFF
--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -1,3 +1,3 @@
-RELATED_IMAGE_ODH_LLAMASTACK_OPERATOR=quay.io/opendatahub/llama-stack-k8s-operator@sha256:f8f66ec02e7f59e510cb20eebfe0c1f6d41b62a9276c6e8e703d258f93d49119
+RELATED_IMAGE_ODH_LLAMASTACK_OPERATOR=quay.io/opendatahub/llama-stack-k8s-operator:latest
 OPERATOR_VERSION=""
 LLAMA_STACK_VERSION=0.2.10


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
this is a similar change to PR #19 
once it is merged, we need sync this change to [RHDS](https://github.com/red-hat-data-services/llama-stack-k8s-operator/tree/main/config/overlays/rhoai) which unblock RHOAI Operator e2e test (we are on rhoai release branch) 
for final production release, https://github.com/red-hat-data-services/RHOAI-Build-Config/blob/rhoai-2.23/bundle/manifests/rhods-operator.clusterserviceversion.yaml#L1501 will be used

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the image reference for a component to use the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->