### PR TITLE
fix: update upstream git repo URL and point to the version which was used for the latest build

### DIFF
--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,7 +1,7 @@
 releases:
   - name: Llama Stack
-    version: odh
-    repoUrl: https://github.com/opendatahub-io/llama-stack
+    version: 0.2.14
+    repoUrl: https://github.com/llamastack/llama-stack
   - name: Open Data Hub Llama Stack Operator
     version: odh
     repoUrl: https://github.com/opendatahub-io/llama-stack-k8s-operator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
latest build https://github.com/opendatahub-io/llama-stack/actions/runs/17262248033/job/48986223074
`RUN pip install --no-cache llama-stack==0.2.14`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Llama Stack release metadata to version 0.2.14 and replaced the repository link with the new official URL, ensuring accurate linking in component details.
  * No changes to the Open Data Hub Llama Stack Operator entry.

* **Documentation**
  * Refreshed the Llama Stack repository reference shown to users to point to the current official source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->