### PR TITLE
[sync] Upstream updates for 2.25

### DIFF
--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -253,7 +253,7 @@ jobs:
           make image-build IMG=quay.io/llamastack/llama-stack-k8s-operator:v${{ env.operator_version }}
 
       - name: Log in to Quay.io
-        uses: docker/login-action@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           registry: quay.io
           username: ${{ secrets.APP_QUAY_USERNAME }}

--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -364,8 +364,8 @@ done`, CABundleTempPath, CABundleSourceDir, fileList)
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
-			AllowPrivilegeEscalation: &[]bool{false}[0],
-			RunAsNonRoot:             &[]bool{false}[0],
+			AllowPrivilegeEscalation: ptr.To(false),
+			RunAsNonRoot:             ptr.To(false),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 			},
@@ -444,8 +444,12 @@ func configurePersistentStorage(instance *llamav1alpha1.LlamaStackDistribution, 
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:  ptr.To(int64(0)), // Run as root to be able to change ownership
-			RunAsGroup: ptr.To(int64(0)),
+			RunAsUser:                ptr.To(int64(0)), // Run as root to be able to change ownership
+			RunAsGroup:               ptr.To(int64(0)),
+			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
 		},
 	}
 
@@ -597,6 +601,16 @@ func configurePodOverrides(instance *llamav1alpha1.LlamaStackDistribution, podSp
 		podSpec.ServiceAccountName = instance.Spec.Server.PodOverrides.ServiceAccountName
 	} else {
 		podSpec.ServiceAccountName = instance.Name + "-sa"
+	}
+
+	// Configure pod-level security context for OpenShift SCC compatibility
+	if podSpec.SecurityContext == nil {
+		podSpec.SecurityContext = &corev1.PodSecurityContext{}
+	}
+
+	// Set fsGroup to allow write access to mounted volumes
+	if podSpec.SecurityContext.FSGroup == nil {
+		podSpec.SecurityContext.FSGroup = ptr.To(int64(0))
 	}
 
 	// Apply other pod overrides if specified


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved OpenShift SCC compatibility with consistent default security contexts.
  - Applied default pod security context when missing and set FSGroup=0 for mounted volume write access.
  - Containers and init containers now default to RunAsNonRoot, disallow privilege escalation, and drop all capabilities by default.
  - More reliable behavior when security settings aren’t explicitly provided.

- Chores
  - Updated Docker Quay login action in the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->