### PR TITLE
Sync changes for 3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v1.64.4
 YQ_VERSION ?= v4.45.3
 YAMLFMT_VERSION ?= v0.12.0
-CRD_REF_DOCS_VERSION = v0.1.0
+CRD_REF_DOCS_VERSION = v0.2.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -42,8 +43,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -240,10 +239,16 @@ func (r *LlamaStackDistributionReconciler) determineKindsToExclude(instance *lla
 	return kinds
 }
 
-// reconcileManifestResources applies resources that are managed by the operator
-// based on the instance specification.
-func (r *LlamaStackDistributionReconciler) reconcileManifestResources(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution) error {
-	resMap, err := deploy.RenderManifest(filesys.MakeFsOnDisk(), manifestsBasePath, instance)
+// reconcileAllManifestResources applies all manifest-based resources using kustomize.
+func (r *LlamaStackDistributionReconciler) reconcileAllManifestResources(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution) error {
+	// Build manifest context for Deployment
+	manifestCtx, err := r.buildManifestContext(ctx, instance)
+	if err != nil {
+		return fmt.Errorf("failed to build manifest context: %w", err)
+	}
+
+	// Render manifests with context
+	resMap, err := deploy.RenderManifestWithContext(filesys.MakeFsOnDisk(), manifestsBasePath, instance, manifestCtx)
 	if err != nil {
 		return fmt.Errorf("failed to render manifests: %w", err)
 	}
@@ -254,6 +259,12 @@ func (r *LlamaStackDistributionReconciler) reconcileManifestResources(ctx contex
 		return fmt.Errorf("failed to filter manifests: %w", err)
 	}
 
+	// Delete excluded resources that might exist from previous reconciliations
+	if err := r.deleteExcludedResources(ctx, instance, kindsToExclude); err != nil {
+		return fmt.Errorf("failed to delete excluded resources: %w", err)
+	}
+
+	// Apply resources to cluster
 	if err := deploy.ApplyResources(ctx, r.Client, r.Scheme, instance, filteredResMap); err != nil {
 		return fmt.Errorf("failed to apply manifests: %w", err)
 	}
@@ -261,31 +272,109 @@ func (r *LlamaStackDistributionReconciler) reconcileManifestResources(ctx contex
 	return nil
 }
 
+// deleteExcludedResources deletes resources that are excluded from the current reconciliation
+// but might exist from previous reconciliations.
+func (r *LlamaStackDistributionReconciler) deleteExcludedResources(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution, kindsToExclude []string) error {
+	logger := log.FromContext(ctx)
+
+	if slices.Contains(kindsToExclude, "NetworkPolicy") {
+		if err := r.deleteNetworkPolicyIfExists(ctx, instance); err != nil {
+			logger.Error(err, "Failed to delete NetworkPolicy")
+			return err
+		}
+	}
+
+	return nil
+}
+
+// deleteNetworkPolicyIfExists deletes the NetworkPolicy if it exists.
+func (r *LlamaStackDistributionReconciler) deleteNetworkPolicyIfExists(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution) error {
+	logger := log.FromContext(ctx)
+
+	networkPolicy := &networkingv1.NetworkPolicy{}
+	networkPolicyName := instance.Name + "-network-policy"
+	key := types.NamespacedName{Name: networkPolicyName, Namespace: instance.Namespace}
+
+	err := r.Get(ctx, key, networkPolicy)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			// NetworkPolicy doesn't exist, nothing to delete
+			return nil
+		}
+		return fmt.Errorf("failed to get NetworkPolicy: %w", err)
+	}
+
+	// Check if this NetworkPolicy is owned by our instance
+	if !metav1.IsControlledBy(networkPolicy, instance) {
+		logger.V(1).Info("NetworkPolicy not owned by this instance, skipping deletion",
+			"networkPolicy", networkPolicyName)
+		return nil
+	}
+
+	logger.Info("Deleting NetworkPolicy as feature is disabled", "networkPolicy", networkPolicyName)
+	if err := r.Delete(ctx, networkPolicy); err != nil {
+		return fmt.Errorf("failed to delete NetworkPolicy: %w", err)
+	}
+
+	return nil
+}
+
+// buildManifestContext creates the manifest context for Deployment using existing helper functions.
+func (r *LlamaStackDistributionReconciler) buildManifestContext(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution) (*deploy.ManifestContext, error) {
+	// Validate distribution configuration
+	if err := r.validateDistribution(instance); err != nil {
+		return nil, err
+	}
+
+	resolvedImage, err := r.resolveImage(instance.Spec.Server.Distribution)
+	if err != nil {
+		return nil, err
+	}
+
+	container := buildContainerSpec(ctx, r, instance, resolvedImage)
+	podSpec := configurePodStorage(ctx, r, instance, container)
+
+	// Get UserConfigMap hash if needed
+	var configMapHash string
+	if r.hasUserConfigMap(instance) {
+		configMapHash, err = r.getConfigMapHash(ctx, instance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get ConfigMap hash: %w", err)
+		}
+	}
+
+	// Get CA bundle hash if needed
+	var caBundleHash string
+	if r.hasCABundleConfigMap(instance) {
+		caBundleHash, err = r.getCABundleConfigMapHash(ctx, instance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get CA bundle ConfigMap hash: %w", err)
+		}
+	}
+
+	podSpecMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&podSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert pod spec to map: %w", err)
+	}
+
+	return &deploy.ManifestContext{
+		ResolvedImage: resolvedImage,
+		ConfigMapHash: configMapHash,
+		CABundleHash:  caBundleHash,
+		PodSpec:       podSpecMap,
+	}, nil
+}
+
 // reconcileResources reconciles all resources for the LlamaStackDistribution instance.
 func (r *LlamaStackDistributionReconciler) reconcileResources(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution) error {
-	// Reconcile ConfigMaps
+	// Reconcile ConfigMaps first
 	if err := r.reconcileConfigMaps(ctx, instance); err != nil {
 		return err
 	}
 
-	// Reconcile storage
-	if err := r.reconcileStorage(ctx, instance); err != nil {
+	// Reconcile all manifest-based resources including Deployment: PVC, ServiceAccount, Service, NetworkPolicy, Deployment
+	if err := r.reconcileAllManifestResources(ctx, instance); err != nil {
 		return err
-	}
-
-	// Reconcile manifest-based resources
-	if err := r.reconcileManifestResources(ctx, instance); err != nil {
-		return err
-	}
-
-	// Reconcile the NetworkPolicy
-	if err := r.reconcileNetworkPolicy(ctx, instance); err != nil {
-		return fmt.Errorf("failed to reconcile NetworkPolicy: %w", err)
-	}
-
-	// Reconcile the Deployment
-	if err := r.reconcileDeployment(ctx, instance); err != nil {
-		return fmt.Errorf("failed to reconcile Deployment: %w", err)
 	}
 
 	return nil
@@ -303,21 +392,6 @@ func (r *LlamaStackDistributionReconciler) reconcileConfigMaps(ctx context.Conte
 	if r.hasCABundleConfigMap(instance) {
 		if err := r.reconcileCABundleConfigMap(ctx, instance); err != nil {
 			return fmt.Errorf("failed to reconcile CA bundle ConfigMap: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (r *LlamaStackDistributionReconciler) reconcileStorage(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution) error {
-	// Reconcile the PVC if storage is configured
-	if instance.Spec.Server.Storage != nil {
-		resMap, err := deploy.RenderManifest(filesys.MakeFsOnDisk(), manifestsBasePath, instance)
-		if err != nil {
-			return fmt.Errorf("failed to render PVC manifests: %w", err)
-		}
-		if err := deploy.ApplyResources(ctx, r.Client, r.Scheme, instance, resMap); err != nil {
-			return fmt.Errorf("failed to apply PVC manifests: %w", err)
 		}
 	}
 
@@ -741,89 +815,6 @@ func (r *LlamaStackDistributionReconciler) convertToReconcileRequests(attachedLl
 	return requests
 }
 
-// reconcileDeployment manages the Deployment for the LlamaStack server.
-func (r *LlamaStackDistributionReconciler) reconcileDeployment(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution) error {
-	logger := log.FromContext(ctx)
-
-	// Validate distribution configuration
-	if err := r.validateDistribution(instance); err != nil {
-		return err
-	}
-
-	// Get the image either from the map or direct reference
-	resolvedImage, err := r.resolveImage(instance.Spec.Server.Distribution)
-	if err != nil {
-		return err
-	}
-
-	// Build container spec
-	container := buildContainerSpec(ctx, r, instance, resolvedImage)
-
-	// Configure storage
-	podSpec := configurePodStorage(ctx, r, instance, container)
-
-	// Set the service acc
-	// Prepare annotations for the pod template
-	podAnnotations := make(map[string]string)
-
-	// Add ConfigMap hash to trigger restarts when the ConfigMap changes
-	if r.hasUserConfigMap(instance) {
-		configMapHash, err := r.getConfigMapHash(ctx, instance)
-		if err != nil {
-			return fmt.Errorf("failed to get ConfigMap hash for pod restart annotation: %w", err)
-		}
-		if configMapHash != "" {
-			podAnnotations["configmap.hash/user-config"] = configMapHash
-			logger.V(1).Info("Added ConfigMap hash annotation to trigger pod restart",
-				"configMapName", instance.Spec.Server.UserConfig.ConfigMapName,
-				"hash", configMapHash)
-		}
-	}
-
-	// Add CA bundle ConfigMap hash to trigger restarts when the CA bundle changes
-	if r.hasCABundleConfigMap(instance) {
-		caBundleHash, err := r.getCABundleConfigMapHash(ctx, instance)
-		if err != nil {
-			return fmt.Errorf("failed to get CA bundle ConfigMap hash for pod restart annotation: %w", err)
-		}
-		if caBundleHash != "" {
-			podAnnotations["configmap.hash/ca-bundle"] = caBundleHash
-			logger.V(1).Info("Added CA bundle ConfigMap hash annotation to trigger pod restart",
-				"configMapName", instance.Spec.Server.TLSConfig.CABundle.ConfigMapName,
-				"hash", caBundleHash)
-		}
-	}
-
-	// Create deployment object
-	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name,
-			Namespace: instance.Namespace,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: &instance.Spec.Replicas,
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					llamav1alpha1.DefaultLabelKey: llamav1alpha1.DefaultLabelValue,
-					"app.kubernetes.io/instance":  instance.Name,
-				},
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						llamav1alpha1.DefaultLabelKey: llamav1alpha1.DefaultLabelValue,
-						"app.kubernetes.io/instance":  instance.Name,
-					},
-					Annotations: podAnnotations,
-				},
-				Spec: podSpec,
-			},
-		},
-	}
-
-	return deploy.ApplyDeployment(ctx, r.Client, r.Scheme, instance, deployment, logger)
-}
-
 // getServerURL returns the URL for the LlamaStack server.
 func (r *LlamaStackDistributionReconciler) getServerURL(instance *llamav1alpha1.LlamaStackDistribution, path string) *url.URL {
 	serviceName := deploy.GetServiceName(instance)
@@ -1047,86 +1038,6 @@ func (r *LlamaStackDistributionReconciler) updateDistributionConfig(instance *ll
 		activeDistribution = "custom"
 	}
 	instance.Status.DistributionConfig.ActiveDistribution = activeDistribution
-}
-
-// reconcileNetworkPolicy manages the NetworkPolicy for the LlamaStack server.
-func (r *LlamaStackDistributionReconciler) reconcileNetworkPolicy(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution) error {
-	logger := log.FromContext(ctx)
-	networkPolicy := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name + "-network-policy",
-			Namespace: instance.Namespace,
-		},
-	}
-
-	// If feature is disabled, delete the NetworkPolicy if it exists
-	if !r.EnableNetworkPolicy {
-		return deploy.HandleDisabledNetworkPolicy(ctx, r.Client, networkPolicy, logger)
-	}
-
-	port := deploy.GetServicePort(instance)
-
-	// get operator namespace
-	operatorNamespace, err := deploy.GetOperatorNamespace()
-	if err != nil {
-		return fmt.Errorf("failed to get operator namespace: %w", err)
-	}
-
-	networkPolicy.Spec = networkingv1.NetworkPolicySpec{
-		PodSelector: metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				llamav1alpha1.DefaultLabelKey: llamav1alpha1.DefaultLabelValue,
-				"app.kubernetes.io/instance":  instance.Name,
-			},
-		},
-		PolicyTypes: []networkingv1.PolicyType{
-			networkingv1.PolicyTypeIngress,
-		},
-		Ingress: []networkingv1.NetworkPolicyIngressRule{
-			{
-				From: []networkingv1.NetworkPolicyPeer{
-					{ // to match all pods in all namespaces
-						PodSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"app.kubernetes.io/part-of": llamav1alpha1.DefaultContainerName,
-							},
-						},
-						NamespaceSelector: &metav1.LabelSelector{}, // Empty namespaceSelector to match all namespaces
-					},
-				},
-				Ports: []networkingv1.NetworkPolicyPort{
-					{
-						Protocol: (*corev1.Protocol)(ptr.To("TCP")),
-						Port: &intstr.IntOrString{
-							IntVal: port,
-						},
-					},
-				},
-			},
-			{
-				From: []networkingv1.NetworkPolicyPeer{
-					{ // to match all pods in matched namespace
-						PodSelector: &metav1.LabelSelector{},
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"kubernetes.io/metadata.name": operatorNamespace,
-							},
-						},
-					},
-				},
-				Ports: []networkingv1.NetworkPolicyPort{
-					{
-						Protocol: (*corev1.Protocol)(ptr.To("TCP")),
-						Port: &intstr.IntOrString{
-							IntVal: port,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	return deploy.ApplyNetworkPolicy(ctx, r.Client, r.Scheme, instance, networkPolicy, logger)
 }
 
 // reconcileUserConfigMap validates that the referenced ConfigMap exists.

--- a/controllers/manifests/base/deployment.yaml
+++ b/controllers/manifests/base/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment  # Will be set to instance.Name by field transformation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llama-stack
+      app.kubernetes.io/instance: ""
+  template:
+    metadata:
+      labels:
+        app: llama-stack
+        app.kubernetes.io/instance: ""
+      annotations: {}
+    spec:
+      serviceAccountName: sa
+      containers: []  # Will be populated by controller
+      volumes: []     # Will be populated by controller
+      initContainers: []  # Will be populated by controller

--- a/controllers/manifests/base/kustomization.yaml
+++ b/controllers/manifests/base/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
 - serviceaccount.yaml
 - scc-binding.yaml
 - service.yaml
+- networkpolicy.yaml
+- deployment.yaml
 
 labels:
 - includeSelectors: false

--- a/controllers/manifests/base/networkpolicy.yaml
+++ b/controllers/manifests/base/networkpolicy.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: llama-stack
+      app.kubernetes.io/instance: ""
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/part-of: llama-stack
+      namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 8321
+  - from:
+    - podSelector: {}
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ""  # Will be set to operator namespace
+    ports:
+    - protocol: TCP
+      port: 8321

--- a/controllers/manifests/base/service.yaml
+++ b/controllers/manifests/base/service.yaml
@@ -4,7 +4,9 @@ metadata:
   name: service
 spec:
   type: ClusterIP
-  selector: {}
+  selector:
+    app: llama-stack
+    app.kubernetes.io/instance: ""  # Will be set by field transformation
   ports:
   - name: http
     protocol: TCP

--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -348,10 +348,9 @@ for key in %s; do
 done`, CABundleTempPath, CABundleSourceDir, fileList)
 
 	return corev1.Container{
-		Name:            CABundleInitName,
-		Image:           image,
-		ImagePullPolicy: corev1.PullAlways,
-		Command:         []string{"/bin/sh", "-c", script},
+		Name:    CABundleInitName,
+		Image:   image,
+		Command: []string{"/bin/sh", "-c", script},
 		// No Args needed since we embed the file list in the script
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -430,9 +429,8 @@ func configurePersistentStorage(instance *llamav1alpha1.LlamaStackDistribution, 
 	command := strings.Join(commands, " && ")
 
 	initContainer := corev1.Container{
-		Name:            "update-pvc-permissions",
-		Image:           image,
-		ImagePullPolicy: corev1.PullAlways,
+		Name:  "update-pvc-permissions",
+		Image: image,
 		Command: []string{
 			"/bin/sh",
 			"-c",

--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -308,7 +308,7 @@ func createCABundleVolume(caBundleConfig *llamav1alpha1.CABundleConfig) corev1.V
 
 // createCABundleInitContainer creates an InitContainer that concatenates multiple CA bundle keys
 // from a ConfigMap into a single file in the shared ca-bundle volume.
-func createCABundleInitContainer(caBundleConfig *llamav1alpha1.CABundleConfig) (corev1.Container, error) {
+func createCABundleInitContainer(caBundleConfig *llamav1alpha1.CABundleConfig, image string) (corev1.Container, error) {
 	// Validate ConfigMap keys for security
 	if err := validateConfigMapKeys(caBundleConfig.ConfigMapKeys); err != nil {
 		return corev1.Container{}, fmt.Errorf("failed to validate ConfigMap keys: %w", err)
@@ -348,9 +348,10 @@ for key in %s; do
 done`, CABundleTempPath, CABundleSourceDir, fileList)
 
 	return corev1.Container{
-		Name:    CABundleInitName,
-		Image:   "registry.access.redhat.com/ubi9/ubi-minimal:latest",
-		Command: []string{"/bin/sh", "-c", script},
+		Name:            CABundleInitName,
+		Image:           image,
+		ImagePullPolicy: corev1.PullAlways,
+		Command:         []string{"/bin/sh", "-c", script},
 		// No Args needed since we embed the file list in the script
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -380,10 +381,10 @@ func configurePodStorage(ctx context.Context, r *LlamaStackDistributionReconcile
 	}
 
 	// Configure storage volumes and init containers
-	configureStorage(instance, &podSpec)
+	configureStorage(instance, &podSpec, container.Image)
 
 	// Configure TLS CA bundle (with auto-detection support)
-	configureTLSCABundle(ctx, r, instance, &podSpec)
+	configureTLSCABundle(ctx, r, instance, &podSpec, container.Image)
 
 	// Configure user config
 	configureUserConfig(instance, &podSpec)
@@ -395,16 +396,16 @@ func configurePodStorage(ctx context.Context, r *LlamaStackDistributionReconcile
 }
 
 // configureStorage handles storage volume configuration.
-func configureStorage(instance *llamav1alpha1.LlamaStackDistribution, podSpec *corev1.PodSpec) {
+func configureStorage(instance *llamav1alpha1.LlamaStackDistribution, podSpec *corev1.PodSpec, image string) {
 	if instance.Spec.Server.Storage != nil {
-		configurePersistentStorage(instance, podSpec)
+		configurePersistentStorage(instance, podSpec, image)
 	} else {
 		configureEmptyDirStorage(podSpec)
 	}
 }
 
 // configurePersistentStorage sets up PVC-based storage with init container for permissions.
-func configurePersistentStorage(instance *llamav1alpha1.LlamaStackDistribution, podSpec *corev1.PodSpec) {
+func configurePersistentStorage(instance *llamav1alpha1.LlamaStackDistribution, podSpec *corev1.PodSpec, image string) {
 	// Use PVC for persistent storage
 	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 		Name: "lls-storage",
@@ -429,8 +430,9 @@ func configurePersistentStorage(instance *llamav1alpha1.LlamaStackDistribution, 
 	command := strings.Join(commands, " && ")
 
 	initContainer := corev1.Container{
-		Name:  "update-pvc-permissions",
-		Image: "registry.access.redhat.com/ubi9/ubi-minimal:latest",
+		Name:            "update-pvc-permissions",
+		Image:           image,
+		ImagePullPolicy: corev1.PullAlways,
 		Command: []string{
 			"/bin/sh",
 			"-c",
@@ -472,26 +474,26 @@ func configureEmptyDirStorage(podSpec *corev1.PodSpec) {
 // in a shared emptyDir volume, which the main container then mounts via SubPath.
 // For single key: uses a direct ConfigMap volume mount.
 // If no explicit CA bundle is configured, it checks for the well-known ODH trusted CA bundle ConfigMap.
-func configureTLSCABundle(ctx context.Context, r *LlamaStackDistributionReconciler, instance *llamav1alpha1.LlamaStackDistribution, podSpec *corev1.PodSpec) {
+func configureTLSCABundle(ctx context.Context, r *LlamaStackDistributionReconciler, instance *llamav1alpha1.LlamaStackDistribution, podSpec *corev1.PodSpec, image string) {
 	tlsConfig := instance.Spec.Server.TLSConfig
 
 	// Handle explicit CA bundle configuration first
 	if tlsConfig != nil && tlsConfig.CABundle != nil {
-		addExplicitCABundle(ctx, tlsConfig.CABundle, podSpec)
+		addExplicitCABundle(ctx, tlsConfig.CABundle, podSpec, image)
 		return
 	}
 
 	// If no explicit CA bundle is configured, check for ODH trusted CA bundle auto-detection
 	if r != nil {
-		addAutoDetectedCABundle(ctx, r, instance, podSpec)
+		addAutoDetectedCABundle(ctx, r, instance, podSpec, image)
 	}
 }
 
 // addExplicitCABundle handles explicitly configured CA bundles.
-func addExplicitCABundle(ctx context.Context, caBundleConfig *llamav1alpha1.CABundleConfig, podSpec *corev1.PodSpec) {
+func addExplicitCABundle(ctx context.Context, caBundleConfig *llamav1alpha1.CABundleConfig, podSpec *corev1.PodSpec, image string) {
 	// Add CA bundle InitContainer if multiple keys are specified
 	if len(caBundleConfig.ConfigMapKeys) > 0 {
-		caBundleInitContainer, err := createCABundleInitContainer(caBundleConfig)
+		caBundleInitContainer, err := createCABundleInitContainer(caBundleConfig, image)
 		if err != nil {
 			log.FromContext(ctx).Error(err, "Failed to create CA bundle init container")
 			return
@@ -520,7 +522,7 @@ func addExplicitCABundle(ctx context.Context, caBundleConfig *llamav1alpha1.CABu
 }
 
 // addAutoDetectedCABundle handles auto-detection of ODH trusted CA bundle ConfigMap.
-func addAutoDetectedCABundle(ctx context.Context, r *LlamaStackDistributionReconciler, instance *llamav1alpha1.LlamaStackDistribution, podSpec *corev1.PodSpec) {
+func addAutoDetectedCABundle(ctx context.Context, r *LlamaStackDistributionReconciler, instance *llamav1alpha1.LlamaStackDistribution, podSpec *corev1.PodSpec, image string) {
 	if r == nil {
 		return
 	}
@@ -544,7 +546,7 @@ func addAutoDetectedCABundle(ctx context.Context, r *LlamaStackDistributionRecon
 	}
 
 	// Use the same logic as explicit configuration
-	caBundleInitContainer, err := createCABundleInitContainer(autoCaBundleConfig)
+	caBundleInitContainer, err := createCABundleInitContainer(autoCaBundleConfig, image)
 	if err != nil {
 		// Log error and skip auto-detected CA bundle configuration
 		log.FromContext(ctx).Error(err, "Failed to create CA bundle init container for auto-detected ConfigMap")

--- a/pkg/deploy/kustomizer_test.go
+++ b/pkg/deploy/kustomizer_test.go
@@ -140,7 +140,7 @@ resources:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: my-app`
+  name: deployment`
 		require.NoError(t, fsys.WriteFile(filepath.Join(defaultPath, "deployment.yaml"), []byte(deploymentContent)))
 
 		owner := &llamav1alpha1.LlamaStackDistribution{
@@ -158,7 +158,7 @@ metadata:
 		require.Equal(t, 1, (*resMap).Size())
 		res := (*resMap).Resources()[0]
 		require.Equal(t, "Deployment", res.GetKind())
-		require.Equal(t, "test-instance-my-app", res.GetName())
+		require.Equal(t, "test-instance", res.GetName())
 		assert.Equal(t, "test-fallback-ns", res.GetNamespace(), "Deployment should have the correct namespace set by plugin")
 	})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces managed Deployment and optional NetworkPolicy for LlamaStack pods.
  * Manifests now render with runtime context (image, config/CA hashes, pod spec) for smoother rollouts.
* **Improvements**
  * Service now correctly selects LlamaStack pods via labels.
  * Centralized reconciliation with automatic cleanup of resources when features/storage are disabled.
  * Status updates now reflect operator version and provider info when ready.
* **Chores**
  * Bumped CRD reference docs version to v0.2.0.
* **Tests**
  * Updated expectations to align with new Deployment naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->