### PR TITLE
[cherry-pick] fix: Update networkpolicy to remove podSelectors (#227)

### DIFF
--- a/api/v1alpha1/llamastackdistribution_types.go
+++ b/api/v1alpha1/llamastackdistribution_types.go
@@ -82,7 +82,7 @@ type LlamaStackDistributionSpec struct {
 
 // NetworkSpec defines network access controls for the LlamaStack service.
 type NetworkSpec struct {
-	// ExposeRoute when true, creates an Ingress (or OpenShift Route) for external access.
+	// ExposeRoute when true, creates an Ingress for external access.
 	// Default is false (internal access only).
 	// +optional
 	// +kubebuilder:default:=false

--- a/config/crd/bases/llamastack.io_llamastackdistributions.yaml
+++ b/config/crd/bases/llamastack.io_llamastackdistributions.yaml
@@ -84,7 +84,7 @@ spec:
                   exposeRoute:
                     default: false
                     description: |-
-                      ExposeRoute when true, creates an Ingress (or OpenShift Route) for external access.
+                      ExposeRoute when true, creates an Ingress for external access.
                       Default is false (internal access only).
                     type: boolean
                 type: object

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -178,7 +178,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `exposeRoute` _boolean_ | ExposeRoute when true, creates an Ingress (or OpenShift Route) for external access.<br />Default is false (internal access only). | false |  |
+| `exposeRoute` _boolean_ | ExposeRoute when true, creates an Ingress for external access.<br />Default is false (internal access only). | false |  |
 | `allowedFrom` _[AllowedFromSpec](#allowedfromspec)_ | AllowedFrom defines which namespaces are allowed to access the LlamaStack service.<br />By default, only the LLSD namespace and the operator namespace are allowed. |  |  |
 
 #### PodDisruptionBudgetSpec

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -93,7 +93,7 @@ spec:
                   exposeRoute:
                     default: false
                     description: |-
-                      ExposeRoute when true, creates an Ingress (or OpenShift Route) for external access.
+                      ExposeRoute when true, creates an Ingress for external access.
                       Default is false (internal access only).
                     type: boolean
                 type: object


### PR DESCRIPTION
- With NetworkPolicy enabled, external traffic through OpenShift Routes is blocked even when the correct namespaces/labels are configured in allowedFrom. This is because the NetworkPolicy includes an explicit `podSelector: {}` in the ingress rules, which doesn't match HostNetwork traffic from the OpenShift router.
- Remove references to managed OpenShift Route. LLS operator only creates Ingress resource.

Approved-by: leseb

Approved-by: nathan-weinberg
(cherry picked from commit a56f0f1cedbb99228fa459009a59c9caa7aff792)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external access configuration descriptions across API definitions and documentation to clarify that Ingress resources are used for external access.

* **New Features**
  * Enhanced network policies to support ingress traffic from OpenShift router namespaces when network exposure is enabled.

* **Tests**
  * Added test coverage for router peer behavior in network policies based on network configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->