### PR TITLE
build(golang): update Go to 1.25 for CVE-2025-61729 (#231)

### DIFF
--- a/.github/workflows/main-build-image.yml
+++ b/.github/workflows/main-build-image.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: Set up Go 1.24
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - name: Set up Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -20,8 +20,8 @@ jobs:
   build-release-image:
     runs-on: ubuntu-24.04
     steps:
-      - name: Set up Go 1.24
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - name: Set up Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version-file: go.mod
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GOLANG_VERSION=1.24
+ARG GOLANG_VERSION=1.25
 
 FROM registry.access.redhat.com/ubi9/go-toolset:${GOLANG_VERSION} as builder
 ARG TARGETOS=linux

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests. Use TEST_PKGS and TEST_FLAGS to customize.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(TEST_PKGS) $(TEST_FLAGS)
+	GOTOOLCHAIN=go1.25.5+auto KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(TEST_PKGS) $(TEST_FLAGS)
 
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/llamastack/llama-stack-k8s-operator
 
-go 1.24.6
+go 1.25.5
 
 require (
 	github.com/go-logr/logr v1.4.1


### PR DESCRIPTION
Update Go from 1.24 to 1.25 to address CVE-2025-61729, a denial-of-service vulnerability in `crypto/x509.HostnameError.Error()`.

- **CVE**: CVE-2025-61729
- **Affected**: crypto/x509 in Go < 1.24.11 and 1.25.0-1.25.4
- **Impact**: Certificates with excessive hostnames cause quadratic runtime during error string construction
- **Patched in**: Go 1.25.5 and 1.24.11

The operator is potentially affected through Kubernetes client-go dependencies which perform TLS hostname verification.

**Reference**: https://pkg.go.dev/vuln/GO-2025-4155

Approved-by: derekhiggins

Approved-by: VaishnaviHire

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
