### PR TITLE
chore: sync upstream v0.9.0 release to odh

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -98,7 +98,7 @@ jobs:
           fi
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v 6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v 6.4.0
         with:
           go-version-file: go.mod
 
@@ -223,7 +223,7 @@ jobs:
           ref: ${{ env.release_branch }}
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go env
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ARG TARGETPLATFORM
 # For native builds: CGO_ENABLED=1 with full FIPS OpenSSL support
 # For cross-builds: CGO_ENABLED=0 with pure Go FIPS (strictfipsruntime)
 ENV GOEXPERIMENT=strictfipsruntime
+ENV GOTOOLCHAIN=auto
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests. Use TEST_PKGS and TEST_FLAGS to customize.
-	GOTOOLCHAIN=go1.25.5+auto KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(TEST_PKGS) $(TEST_FLAGS)
+	GOTOOLCHAIN=go1.25.8+auto KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(TEST_PKGS) $(TEST_FLAGS)
 
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ spec:
 ```
 3. Verify the server pod is running in the user defined namespace.
 
+### Local Vector Storage (inline::milvus)
+
+To enable the `inline::milvus` local vector storage provider, set `ENABLE_INLINE_MILVUS` in `spec.server.containerSpec.env`. This is only supported in single-worker, single-replica deployments. Milvus-Lite uses SQLite internally and does not support concurrent access from multiple processes.
+
 ### Using a ConfigMap for config.yaml configuration
 
 A ConfigMap can be used to store config.yaml configuration for each LlamaStackDistribution.

--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,7 +1,7 @@
 releases:
   - name: Llama Stack
-    version: v0.6.0
+    version: v0.7.1
     repoUrl: https://github.com/opendatahub-io/llama-stack-distribution
   - name: Llama Stack Operator
-    version: v0.8.0
+    version: v0.9.0
     repoUrl: https://github.com/opendatahub-io/llama-stack-k8s-operator

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,4 +16,4 @@ configMapGenerator:
 images:
 - name: controller
   newName: quay.io/llamastack/llama-stack-k8s-operator
-  newTag: latest
+  newTag: v0.9.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,6 +52,8 @@ spec:
         args:
         - --leader-elect
         env:
+        - name: GOMEMLIMIT
+          value: "800MiB"
         - name: OPERATOR_VERSION
           value: "latest"
         - name: RELATED_IMAGE_RH_DISTRIBUTION

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,7 +55,7 @@ spec:
         - name: GOMEMLIMIT
           value: "800MiB"
         - name: OPERATOR_VERSION
-          value: "latest"
+          value: "0.9.0"
         - name: RELATED_IMAGE_RH_DISTRIBUTION
           value: ""
         image: controller:latest

--- a/config/manager/pdb.yaml
+++ b/config/manager/pdb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: controller-manager-pdb
   namespace: system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
        app.kubernetes.io/name: llama-stack-k8s-operator

--- a/config/samples/_v1alpha1_llamastackdistribution.yaml
+++ b/config/samples/_v1alpha1_llamastackdistribution.yaml
@@ -16,7 +16,7 @@ spec:
       name: starter
     workers: 2
     podDisruptionBudget:
-      minAvailable: 1
+      maxUnavailable: 1
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: topology.kubernetes.io/zone

--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"encoding/json"
@@ -1572,8 +1573,11 @@ func (r *LlamaStackDistributionReconciler) processODHConfigMapKeys(configMap *co
 // rejects invalid X.509 certificates.
 // Returns: (certificates as strings, total size, certificate count, error).
 func extractValidCertificates(data []byte, keyName string) ([]string, int, int, error) {
-	if len(data) == 0 {
-		return nil, 0, 0, fmt.Errorf("failed to process CA bundle key '%s': contains no data", keyName)
+	// Trim whitespace to detect effectively empty data.
+	// Empty or whitespace-only data is valid (e.g., ODH bundle with no custom CAs).
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, 0, 0, nil
 	}
 
 	var certificates []string

--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -78,22 +78,28 @@ const (
 
 	// ODH/RHOAI well-known ConfigMap for trusted CA bundles.
 	odhTrustedCABundleConfigMap = "odh-trusted-ca-bundle"
+
+	// WatchLabelKey is the label key used to include ConfigMaps in the operator's cache.
+	// Operator-managed ConfigMaps get this label automatically. Users can add it to
+	// their ConfigMaps for instant reconciliation on change.
+	WatchLabelKey = "llamastack.io/watch"
+	// WatchLabelValue is the expected value for the watch label.
+	WatchLabelValue = "true"
 )
 
 // LlamaStackDistributionReconciler reconciles a LlamaStack object.
 //
-// ConfigMap Watching Feature:
-// This reconciler watches for changes to ConfigMaps referenced by LlamaStackDistribution CRs.
-// When a ConfigMap's data changes, it automatically triggers reconciliation of the referencing
-// LlamaStackDistribution, which recalculates a content-based hash and updates the deployment's
-// pod template annotations. This causes Kubernetes to restart the pods with the updated configuration.
-//
-// Operator ConfigMap Watching Feature:
-// This reconciler also watches for changes to the operator configuration ConfigMap. When the operator
-// config changes, it triggers reconciliation of all LlamaStackDistribution resources.
+// ConfigMap handling:
+// Operator-managed ConfigMaps (CA bundles) have the managed-by label and are watched
+// via Owns(). User-referenced ConfigMaps and the operator config ConfigMap are read
+// via a direct (non-cached) API client during reconciliation, with periodic requeue
+// (5 minutes) for eventual consistency.
 type LlamaStackDistributionReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	// DirectClient is a non-cached API client for reading ConfigMaps that
+	// lack operator labels (user-referenced and operator config ConfigMaps).
+	DirectClient client.Reader
 	// Feature flags
 	EnableNetworkPolicy bool
 	// Image mapping overrides
@@ -101,6 +107,9 @@ type LlamaStackDistributionReconciler struct {
 	// Cluster info
 	ClusterInfo *cluster.ClusterInfo
 	httpClient  *http.Client
+
+	// Cached operator namespace used for config refresh during reconciliation.
+	operatorNamespace string
 }
 
 // hasUserConfigMap checks if the instance has a valid UserConfig with ConfigMapName.
@@ -133,34 +142,6 @@ func (r *LlamaStackDistributionReconciler) getCABundleConfigMapNamespace(instanc
 	return instance.Namespace
 }
 
-// hasValidUserConfig is a standalone helper function to check if a LlamaStackDistribution has valid UserConfig.
-// This is used by functions that don't have access to the reconciler receiver.
-func hasValidUserConfig(llsd *llamav1alpha1.LlamaStackDistribution) bool {
-	return llsd.Spec.Server.UserConfig != nil && llsd.Spec.Server.UserConfig.ConfigMapName != ""
-}
-
-// getUserConfigMapNamespaceStandalone returns the resolved ConfigMap namespace without needing a receiver.
-func getUserConfigMapNamespaceStandalone(llsd *llamav1alpha1.LlamaStackDistribution) string {
-	if llsd.Spec.Server.UserConfig.ConfigMapNamespace != "" {
-		return llsd.Spec.Server.UserConfig.ConfigMapNamespace
-	}
-	return llsd.Namespace
-}
-
-// hasValidCABundleConfig is a standalone helper function to check if a LlamaStackDistribution has valid CA bundle config.
-// This is used by functions that don't have access to the reconciler receiver.
-func hasValidCABundleConfig(llsd *llamav1alpha1.LlamaStackDistribution) bool {
-	return llsd.Spec.Server.TLSConfig != nil && llsd.Spec.Server.TLSConfig.CABundle != nil && llsd.Spec.Server.TLSConfig.CABundle.ConfigMapName != ""
-}
-
-// getCABundleConfigMapNamespaceStandalone returns the resolved CA bundle ConfigMap namespace without needing a receiver.
-func getCABundleConfigMapNamespaceStandalone(llsd *llamav1alpha1.LlamaStackDistribution) string {
-	if llsd.Spec.Server.TLSConfig.CABundle.ConfigMapNamespace != "" {
-		return llsd.Spec.Server.TLSConfig.CABundle.ConfigMapNamespace
-	}
-	return llsd.Namespace
-}
-
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 // the LlamaStack object against the actual cluster state, and then
@@ -177,6 +158,11 @@ func (r *LlamaStackDistributionReconciler) Reconcile(ctx context.Context, req ct
 	// Always ensure the name of the CR and the namespace are included in the logger.
 	logger := log.FromContext(ctx).WithValues("namespace", req.Namespace, "name", req.Name)
 	ctx = logr.NewContext(ctx, logger)
+
+	// Refresh feature flags and image overrides from the operator config ConfigMap.
+	// This reads via the direct (non-cached) API client so it always gets full data,
+	// even though the informer cache strips ConfigMap data to save memory.
+	r.refreshOperatorConfig(ctx)
 
 	// Fetch the LlamaStack instance
 	instance, err := r.fetchInstance(ctx, req.NamespacedName)
@@ -213,7 +199,51 @@ func (r *LlamaStackDistributionReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	logger.Info("Successfully reconciled LlamaStackDistribution")
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+}
+
+// refreshOperatorConfig re-reads the operator config ConfigMap via the direct
+// API client and updates feature flags and image mapping overrides.
+func (r *LlamaStackDistributionReconciler) refreshOperatorConfig(ctx context.Context) {
+	logger := log.FromContext(ctx)
+
+	operatorNamespace := r.operatorNamespace
+	if operatorNamespace == "" {
+		var err error
+		operatorNamespace, err = deploy.GetOperatorNamespace()
+		if err != nil {
+			logger.Error(err, "failed to get operator namespace for config refresh")
+			return
+		}
+		r.operatorNamespace = operatorNamespace
+	}
+
+	configMap := &corev1.ConfigMap{}
+	if err := r.directGet(ctx, types.NamespacedName{
+		Name:      operatorConfigData,
+		Namespace: operatorNamespace,
+	}, configMap); err != nil {
+		logger.Error(err, "failed to refresh operator config")
+		return
+	}
+
+	enableNetworkPolicy, err := parseFeatureFlags(configMap.Data)
+	if err != nil {
+		logger.Error(err, "failed to parse feature flags")
+	} else {
+		r.EnableNetworkPolicy = enableNetworkPolicy
+	}
+
+	r.ImageMappingOverrides = ParseImageMappingOverrides(ctx, configMap.Data)
+}
+
+// directGet reads an object via the DirectClient (non-cached) if set, otherwise
+// falls back to the cached client. This allows tests to work without a separate client.
+func (r *LlamaStackDistributionReconciler) directGet(ctx context.Context, key types.NamespacedName, obj client.Object) error {
+	if r.DirectClient != nil {
+		return r.DirectClient.Get(ctx, key, obj)
+	}
+	return r.Get(ctx, key, obj)
 }
 
 // fetchInstance retrieves the LlamaStackDistribution instance.
@@ -555,12 +585,7 @@ func (r *LlamaStackDistributionReconciler) reconcileManagedCABundle(ctx context.
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *LlamaStackDistributionReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	// Create a field indexer for ConfigMap references to improve performance
-	if err := r.createConfigMapFieldIndexer(ctx, mgr); err != nil {
-		return err
-	}
-
+func (r *LlamaStackDistributionReconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&llamav1alpha1.LlamaStackDistribution{}, builder.WithPredicates(predicate.Funcs{
 			UpdateFunc: r.llamaStackUpdatePredicate(mgr),
@@ -569,85 +594,16 @@ func (r *LlamaStackDistributionReconciler) SetupWithManager(ctx context.Context,
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
 		Owns(&corev1.Service{}).
+		Owns(&corev1.ConfigMap{}).
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(r.mapConfigMapToReconcileRequests),
+			builder.WithPredicates(r.userConfigMapPredicate()),
+		).
 		Owns(&networkingv1.NetworkPolicy{}).
 		Owns(&networkingv1.Ingress{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
-		Watches(
-			&corev1.ConfigMap{},
-			handler.EnqueueRequestsFromMapFunc(r.findLlamaStackDistributionsForConfigMap),
-			builder.WithPredicates(predicate.Funcs{
-				UpdateFunc: r.configMapUpdatePredicate,
-				CreateFunc: r.configMapCreatePredicate,
-				DeleteFunc: r.configMapDeletePredicate,
-			}),
-		).
 		Complete(r)
-}
-
-// createConfigMapFieldIndexer creates a field indexer for ConfigMap references.
-// On older Kubernetes versions that don't support custom field labels for custom resources,
-// this will fail gracefully and the operator will fall back to manual searching.
-func (r *LlamaStackDistributionReconciler) createConfigMapFieldIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	// Create index for user config ConfigMaps
-	if err := mgr.GetFieldIndexer().IndexField(
-		ctx,
-		&llamav1alpha1.LlamaStackDistribution{},
-		"spec.server.userConfig.configMapName",
-		r.configMapIndexFunc,
-	); err != nil {
-		// Log warning but don't fail startup - older Kubernetes versions may not support this
-		mgr.GetLogger().V(1).Info("Field indexer for ConfigMap references not supported, will use manual search fallback",
-			"error", err.Error())
-		return nil
-	}
-
-	// Create index for CA bundle ConfigMaps
-	if err := mgr.GetFieldIndexer().IndexField(
-		ctx,
-		&llamav1alpha1.LlamaStackDistribution{},
-		"spec.server.tlsConfig.caBundle.configMapName",
-		r.caBundleConfigMapIndexFunc,
-	); err != nil {
-		// Log warning but don't fail startup - older Kubernetes versions may not support this
-		mgr.GetLogger().Info("Field indexer for CA bundle ConfigMap references not supported, will use manual search fallback",
-			"error", err.Error())
-		return nil
-	}
-
-	mgr.GetLogger().V(1).Info("Successfully created field indexer for ConfigMap references - will use efficient lookups")
-	return nil
-}
-
-// configMapIndexFunc is the indexer function for ConfigMap references.
-func (r *LlamaStackDistributionReconciler) configMapIndexFunc(rawObj client.Object) []string {
-	llsd, ok := rawObj.(*llamav1alpha1.LlamaStackDistribution)
-	if !ok {
-		return nil
-	}
-	if !hasValidUserConfig(llsd) {
-		return nil
-	}
-
-	// Create index key as "namespace/name" format
-	configMapNamespace := getUserConfigMapNamespaceStandalone(llsd)
-	indexKey := fmt.Sprintf("%s/%s", configMapNamespace, llsd.Spec.Server.UserConfig.ConfigMapName)
-	return []string{indexKey}
-}
-
-// caBundleConfigMapIndexFunc is the indexer function for CA bundle ConfigMap references.
-func (r *LlamaStackDistributionReconciler) caBundleConfigMapIndexFunc(rawObj client.Object) []string {
-	llsd, ok := rawObj.(*llamav1alpha1.LlamaStackDistribution)
-	if !ok {
-		return nil
-	}
-	if !hasValidCABundleConfig(llsd) {
-		return nil
-	}
-
-	// Create index key as "namespace/name" format
-	configMapNamespace := getCABundleConfigMapNamespaceStandalone(llsd)
-	indexKey := fmt.Sprintf("%s/%s", configMapNamespace, llsd.Spec.Server.TLSConfig.CABundle.ConfigMapName)
-	return []string{indexKey}
 }
 
 // llamaStackUpdatePredicate returns a predicate function for LlamaStackDistribution updates.
@@ -682,351 +638,106 @@ func (r *LlamaStackDistributionReconciler) llamaStackUpdatePredicate(mgr ctrl.Ma
 	}
 }
 
-// configMapUpdatePredicate handles ConfigMap update events.
-func (r *LlamaStackDistributionReconciler) configMapUpdatePredicate(e event.UpdateEvent) bool {
-	oldConfigMap, oldOk := e.ObjectOld.(*corev1.ConfigMap)
-	newConfigMap, newOk := e.ObjectNew.(*corev1.ConfigMap)
+// mapConfigMapToReconcileRequests maps a user-opted-in ConfigMap change to the
+// LlamaStackDistribution CR(s) that reference it.
+func (r *LlamaStackDistributionReconciler) mapConfigMapToReconcileRequests(ctx context.Context, obj client.Object) []reconcile.Request {
+	logger := log.FromContext(ctx)
 
-	if !oldOk || !newOk {
-		return false
+	configMap, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		return nil
 	}
 
-	// Check if this is the operator config ConfigMap
-	if r.handleOperatorConfigUpdate(newConfigMap) {
+	// Skip operator-managed ConfigMaps — they are handled by Owns().
+	if configMap.Labels["app.kubernetes.io/managed-by"] == "llama-stack-operator" {
+		return nil
+	}
+
+	// List all LlamaStackDistribution CRs to find which ones reference this ConfigMap.
+	var instances llamav1alpha1.LlamaStackDistributionList
+	if err := r.List(ctx, &instances); err != nil {
+		logger.Error(err, "failed to list LlamaStackDistribution instances for ConfigMap mapping")
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for i := range instances.Items {
+		instance := &instances.Items[i]
+		if r.instanceReferencesConfigMap(instance, configMap.Name, configMap.Namespace) {
+			logger.Info("ConfigMap change mapped to LlamaStackDistribution",
+				"configMap", configMap.Name, "configMapNamespace", configMap.Namespace,
+				"instance", instance.Name, "instanceNamespace", instance.Namespace)
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      instance.Name,
+					Namespace: instance.Namespace,
+				},
+			})
+		}
+	}
+
+	return requests
+}
+
+// instanceReferencesConfigMap checks if a LlamaStackDistribution instance references
+// a ConfigMap with the given name and namespace.
+func (r *LlamaStackDistributionReconciler) instanceReferencesConfigMap(
+	instance *llamav1alpha1.LlamaStackDistribution, cmName, cmNamespace string,
+) bool {
+	// User config ConfigMap.
+	if r.hasUserConfigMap(instance) &&
+		instance.Spec.Server.UserConfig.ConfigMapName == cmName &&
+		r.getUserConfigMapNamespace(instance) == cmNamespace {
 		return true
 	}
 
-	// Handle referenced ConfigMap updates
-	return r.handleReferencedConfigMapUpdate(oldConfigMap, newConfigMap)
+	// CA bundle source ConfigMap.
+	if r.hasCABundleConfigMap(instance) &&
+		instance.Spec.Server.TLSConfig.CABundle.ConfigMapName == cmName &&
+		r.getCABundleConfigMapNamespace(instance) == cmNamespace {
+		return true
+	}
+
+	// ODH trusted CA bundle well-known ConfigMap (same namespace as instance).
+	if cmName == odhTrustedCABundleConfigMap && cmNamespace == instance.Namespace {
+		return true
+	}
+
+	// Operator config well-known ConfigMap.
+	return cmName == operatorConfigData && cmNamespace == r.operatorNamespace
 }
 
-// handleOperatorConfigUpdate processes updates to the operator config ConfigMap.
-func (r *LlamaStackDistributionReconciler) handleOperatorConfigUpdate(configMap *corev1.ConfigMap) bool {
-	operatorNamespace, err := deploy.GetOperatorNamespace()
-	if err != nil {
+// userConfigMapPredicate returns a predicate that accepts only ConfigMaps with
+// the watch label and rejects operator-managed ConfigMaps (handled by Owns()).
+func (r *LlamaStackDistributionReconciler) userConfigMapPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isWatchLabeledUserConfigMap(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isWatchLabeledUserConfigMap(e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return isWatchLabeledUserConfigMap(e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return isWatchLabeledUserConfigMap(e.Object)
+		},
+	}
+}
+
+// isWatchLabeledUserConfigMap returns true if the object has the watch label
+// and is NOT an operator-managed ConfigMap.
+func isWatchLabeledUserConfigMap(obj client.Object) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
 		return false
 	}
-
-	if configMap.Name != operatorConfigData || configMap.Namespace != operatorNamespace {
+	// Reject operator-managed ConfigMaps — they are handled by Owns().
+	if labels["app.kubernetes.io/managed-by"] == "llama-stack-operator" {
 		return false
 	}
-
-	// Update feature flags
-	EnableNetworkPolicy, err := parseFeatureFlags(configMap.Data)
-	if err != nil {
-		log.FromContext(context.Background()).Error(err, "Failed to parse feature flags")
-	} else {
-		r.EnableNetworkPolicy = EnableNetworkPolicy
-	}
-
-	r.ImageMappingOverrides = ParseImageMappingOverrides(context.Background(), configMap.Data)
-	return true
-}
-
-// handleReferencedConfigMapUpdate processes updates to referenced ConfigMaps.
-func (r *LlamaStackDistributionReconciler) handleReferencedConfigMapUpdate(oldConfigMap, newConfigMap *corev1.ConfigMap) bool {
-	// Only proceed if this ConfigMap is referenced by any LlamaStackDistribution
-	if !r.isConfigMapReferenced(newConfigMap) {
-		return false
-	}
-
-	// Only trigger if Data or BinaryData has changed
-	dataChanged := !cmp.Equal(oldConfigMap.Data, newConfigMap.Data)
-	binaryDataChanged := !cmp.Equal(oldConfigMap.BinaryData, newConfigMap.BinaryData)
-
-	// Log ConfigMap changes for debugging (only for referenced ConfigMaps)
-	if dataChanged || binaryDataChanged {
-		r.logConfigMapDiff(oldConfigMap, newConfigMap, dataChanged, binaryDataChanged)
-	}
-
-	return dataChanged || binaryDataChanged
-}
-
-// logConfigMapDiff logs the differences between old and new ConfigMaps.
-func (r *LlamaStackDistributionReconciler) logConfigMapDiff(oldConfigMap, newConfigMap *corev1.ConfigMap, dataChanged, binaryDataChanged bool) {
-	logger := log.FromContext(context.Background()).WithValues(
-		"configMapName", newConfigMap.Name,
-		"configMapNamespace", newConfigMap.Namespace)
-
-	logger.Info("Referenced ConfigMap change detected")
-
-	if dataChanged {
-		if dataDiff := cmp.Diff(oldConfigMap.Data, newConfigMap.Data); dataDiff != "" {
-			logger.Info("ConfigMap Data changed")
-			fmt.Printf("ConfigMap %s/%s Data diff:\n%s\n", newConfigMap.Namespace, newConfigMap.Name, dataDiff)
-		}
-	}
-
-	if binaryDataChanged {
-		if binaryDataDiff := cmp.Diff(oldConfigMap.BinaryData, newConfigMap.BinaryData); binaryDataDiff != "" {
-			logger.Info("ConfigMap BinaryData changed")
-			fmt.Printf("ConfigMap %s/%s BinaryData diff:\n%s\n", newConfigMap.Namespace, newConfigMap.Name, binaryDataDiff)
-		}
-	}
-}
-
-// configMapCreatePredicate handles ConfigMap create events.
-func (r *LlamaStackDistributionReconciler) configMapCreatePredicate(e event.CreateEvent) bool {
-	configMap, ok := e.Object.(*corev1.ConfigMap)
-	if !ok {
-		return false
-	}
-
-	isReferenced := r.isConfigMapReferenced(configMap)
-	// Log create events for referenced ConfigMaps
-	if isReferenced {
-		log.FromContext(context.Background()).Info("ConfigMap create event detected for referenced ConfigMap",
-			"configMapName", configMap.Name,
-			"configMapNamespace", configMap.Namespace)
-	}
-
-	return isReferenced
-}
-
-// configMapDeletePredicate handles ConfigMap delete events.
-func (r *LlamaStackDistributionReconciler) configMapDeletePredicate(e event.DeleteEvent) bool {
-	configMap, ok := e.Object.(*corev1.ConfigMap)
-	if !ok {
-		return false
-	}
-
-	isReferenced := r.isConfigMapReferenced(configMap)
-	// Log delete events for referenced ConfigMaps - this is critical for deployment health
-	if isReferenced {
-		log.FromContext(context.Background()).Error(nil,
-			"CRITICAL: ConfigMap delete event detected for referenced ConfigMap - this will break dependent deployments",
-			"configMapName", configMap.Name,
-			"configMapNamespace", configMap.Namespace)
-	}
-
-	return isReferenced
-}
-
-// isConfigMapReferenced checks if a ConfigMap is referenced by any LlamaStackDistribution.
-func (r *LlamaStackDistributionReconciler) isConfigMapReferenced(configMap client.Object) bool {
-	logger := log.FromContext(context.Background()).WithValues(
-		"configMapName", configMap.GetName(),
-		"configMapNamespace", configMap.GetNamespace())
-
-	// Use field indexer for efficient lookup - create the same index key format
-	indexKey := fmt.Sprintf("%s/%s", configMap.GetNamespace(), configMap.GetName())
-
-	// Check for user config ConfigMap references
-	userConfigLlamaStacks := llamav1alpha1.LlamaStackDistributionList{}
-	err := r.List(context.Background(), &userConfigLlamaStacks, client.MatchingFields{"spec.server.userConfig.configMapName": indexKey})
-	if err != nil {
-		// Field indexer failed (likely due to older Kubernetes version not supporting custom field labels)
-		// Fall back to a manual check instead of assuming all ConfigMaps are referenced
-		logger.V(1).Info("Field indexer not supported, falling back to manual ConfigMap reference check", "error", err.Error())
-		return r.manuallyCheckConfigMapReference(configMap)
-	}
-
-	found := len(userConfigLlamaStacks.Items) > 0
-
-	// Check for CA bundle ConfigMap references if not found in user config
-	if !found {
-		caBundleLlamaStacks := llamav1alpha1.LlamaStackDistributionList{}
-		err := r.List(context.Background(), &caBundleLlamaStacks, client.MatchingFields{"spec.server.tlsConfig.caBundle.configMapName": indexKey})
-		if err != nil {
-			// Field indexer failed for CA bundle, fall back to manual check
-			logger.V(1).Info("CA bundle field indexer not supported, falling back to manual ConfigMap reference check", "error", err.Error())
-			return r.manuallyCheckConfigMapReference(configMap)
-		}
-		found = len(caBundleLlamaStacks.Items) > 0
-	}
-
-	if !found {
-		// Fallback: manually check all LlamaStackDistributions
-		manuallyFound := r.manuallyCheckConfigMapReference(configMap)
-		if manuallyFound {
-			return true
-		}
-	}
-
-	return found
-}
-
-// manuallyCheckConfigMapReference manually checks if any LlamaStackDistribution references the given ConfigMap.
-func (r *LlamaStackDistributionReconciler) manuallyCheckConfigMapReference(configMap client.Object) bool {
-	logger := log.FromContext(context.Background()).WithValues(
-		"configMapName", configMap.GetName(),
-		"configMapNamespace", configMap.GetNamespace())
-
-	allLlamaStacks := llamav1alpha1.LlamaStackDistributionList{}
-	err := r.List(context.Background(), &allLlamaStacks)
-	if err != nil {
-		logger.Error(err, "CRITICAL: Failed to list all LlamaStackDistributions for manual ConfigMap reference check - assuming ConfigMap is referenced")
-		return true // Return true to trigger reconciliation when we can't determine reference status
-	}
-
-	targetNamespace := configMap.GetNamespace()
-	targetName := configMap.GetName()
-
-	for _, ls := range allLlamaStacks.Items {
-		// Check user config ConfigMap references
-		if hasValidUserConfig(&ls) {
-			configMapNamespace := getUserConfigMapNamespaceStandalone(&ls)
-
-			if configMapNamespace == targetNamespace && ls.Spec.Server.UserConfig.ConfigMapName == targetName {
-				// found a LlamaStackDistribution that references the ConfigMap
-				return true
-			}
-		}
-
-		// Check CA bundle ConfigMap references
-		if hasValidCABundleConfig(&ls) {
-			configMapNamespace := getCABundleConfigMapNamespaceStandalone(&ls)
-
-			if configMapNamespace == targetNamespace && ls.Spec.Server.TLSConfig.CABundle.ConfigMapName == targetName {
-				// found a LlamaStackDistribution that references the CA bundle ConfigMap
-				return true
-			}
-		}
-	}
-
-	// no LlamaStackDistribution found that references the ConfigMap
-	return false
-}
-
-// findLlamaStackDistributionsForConfigMap maps ConfigMap changes to LlamaStackDistribution reconcile requests.
-func (r *LlamaStackDistributionReconciler) findLlamaStackDistributionsForConfigMap(ctx context.Context, configMap client.Object) []reconcile.Request {
-	logger := log.FromContext(ctx).WithValues(
-		"configMapName", configMap.GetName(),
-		"configMapNamespace", configMap.GetNamespace())
-
-	operatorNamespace, err := deploy.GetOperatorNamespace()
-	if err != nil {
-		logger.Error(err, "Failed to get operator namespace for config map event processing")
-		return nil
-	}
-	// If the operator config was changed, we reconcile all LlamaStackDistributions
-	if configMap.GetName() == operatorConfigData && configMap.GetNamespace() == operatorNamespace {
-		// List all LlamaStackDistribution resources across all namespaces
-		allLlamaStacks := llamav1alpha1.LlamaStackDistributionList{}
-		err = r.List(ctx, &allLlamaStacks)
-		if err != nil {
-			logger.Error(err, "Failed to list all LlamaStackDistributions for operator config change")
-			return nil
-		}
-		return r.convertToReconcileRequests(allLlamaStacks)
-	}
-
-	// Try field indexer lookup first
-	attachedLlamaStacks, found := r.tryFieldIndexerLookup(ctx, configMap)
-	if !found {
-		// Fallback to manual search if field indexer returns no results
-		attachedLlamaStacks = r.performManualSearch(ctx, configMap)
-	}
-
-	// Convert to reconcile requests
-	requests := r.convertToReconcileRequests(attachedLlamaStacks)
-
-	return requests
-}
-
-// tryFieldIndexerLookup attempts to find LlamaStackDistributions using the field indexer.
-func (r *LlamaStackDistributionReconciler) tryFieldIndexerLookup(ctx context.Context, configMap client.Object) (llamav1alpha1.LlamaStackDistributionList, bool) {
-	logger := log.FromContext(ctx).WithValues(
-		"configMapName", configMap.GetName(),
-		"configMapNamespace", configMap.GetNamespace())
-
-	indexKey := fmt.Sprintf("%s/%s", configMap.GetNamespace(), configMap.GetName())
-
-	// Check for user config ConfigMap references
-	userConfigLlamaStacks := llamav1alpha1.LlamaStackDistributionList{}
-	err := r.List(ctx, &userConfigLlamaStacks, client.MatchingFields{"spec.server.userConfig.configMapName": indexKey})
-	if err != nil {
-		logger.V(1).Info("Field indexer not supported, will fall back to a manual search for ConfigMap event processing",
-			"indexKey", indexKey, "error", err.Error())
-		return userConfigLlamaStacks, false
-	}
-
-	// Check for CA bundle ConfigMap references
-	caBundleLlamaStacks := llamav1alpha1.LlamaStackDistributionList{}
-	err = r.List(ctx, &caBundleLlamaStacks, client.MatchingFields{"spec.server.tlsConfig.caBundle.configMapName": indexKey})
-	if err != nil {
-		logger.V(1).Info("CA bundle field indexer not supported, will fall back to a manual search for ConfigMap event processing",
-			"indexKey", indexKey, "error", err.Error())
-		return userConfigLlamaStacks, len(userConfigLlamaStacks.Items) > 0
-	}
-
-	// Combine results from both searches
-	combinedLlamaStacks := llamav1alpha1.LlamaStackDistributionList{}
-	combinedLlamaStacks.Items = append(combinedLlamaStacks.Items, userConfigLlamaStacks.Items...)
-	combinedLlamaStacks.Items = append(combinedLlamaStacks.Items, caBundleLlamaStacks.Items...)
-
-	return combinedLlamaStacks, len(combinedLlamaStacks.Items) > 0
-}
-
-// performManualSearch performs a manual search and filtering when field indexer returns no results.
-func (r *LlamaStackDistributionReconciler) performManualSearch(ctx context.Context, configMap client.Object) llamav1alpha1.LlamaStackDistributionList {
-	logger := log.FromContext(ctx).WithValues(
-		"configMapName", configMap.GetName(),
-		"configMapNamespace", configMap.GetNamespace())
-
-	allLlamaStacks := llamav1alpha1.LlamaStackDistributionList{}
-	err := r.List(ctx, &allLlamaStacks)
-	if err != nil {
-		logger.Error(err, "CRITICAL: Failed to list all LlamaStackDistributions for manual ConfigMap reference search")
-		return allLlamaStacks
-	}
-
-	// Filter for ConfigMap references
-	filteredItems := r.filterLlamaStacksForConfigMap(allLlamaStacks.Items, configMap)
-	allLlamaStacks.Items = filteredItems
-
-	return allLlamaStacks
-}
-
-// filterLlamaStacksForConfigMap filters LlamaStackDistributions that reference the given ConfigMap.
-func (r *LlamaStackDistributionReconciler) filterLlamaStacksForConfigMap(llamaStacks []llamav1alpha1.LlamaStackDistribution,
-	configMap client.Object) []llamav1alpha1.LlamaStackDistribution {
-	var filteredItems []llamav1alpha1.LlamaStackDistribution
-	targetNamespace := configMap.GetNamespace()
-	targetName := configMap.GetName()
-
-	for _, ls := range llamaStacks {
-		if r.doesLlamaStackReferenceConfigMap(ls, targetNamespace, targetName) {
-			filteredItems = append(filteredItems, ls)
-		}
-	}
-
-	return filteredItems
-}
-
-// doesLlamaStackReferenceConfigMap checks if a LlamaStackDistribution references the specified ConfigMap.
-func (r *LlamaStackDistributionReconciler) doesLlamaStackReferenceConfigMap(ls llamav1alpha1.LlamaStackDistribution, targetNamespace, targetName string) bool {
-	// Check user config ConfigMap references
-	if hasValidUserConfig(&ls) {
-		configMapNamespace := getUserConfigMapNamespaceStandalone(&ls)
-		if configMapNamespace == targetNamespace && ls.Spec.Server.UserConfig.ConfigMapName == targetName {
-			return true
-		}
-	}
-
-	// Check CA bundle ConfigMap references
-	if hasValidCABundleConfig(&ls) {
-		configMapNamespace := getCABundleConfigMapNamespaceStandalone(&ls)
-		if configMapNamespace == targetNamespace && ls.Spec.Server.TLSConfig.CABundle.ConfigMapName == targetName {
-			return true
-		}
-	}
-
-	return false
-}
-
-// convertToReconcileRequests converts LlamaStackDistribution items to reconcile requests.
-func (r *LlamaStackDistributionReconciler) convertToReconcileRequests(attachedLlamaStacks llamav1alpha1.LlamaStackDistributionList) []reconcile.Request {
-	requests := make([]reconcile.Request, 0, len(attachedLlamaStacks.Items))
-	for _, llamaStack := range attachedLlamaStacks.Items {
-		requests = append(requests, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      llamaStack.Name,
-				Namespace: llamaStack.Namespace,
-			},
-		})
-	}
-	return requests
+	return labels[WatchLabelKey] == WatchLabelValue
 }
 
 // getServerURL returns the URL for the LlamaStack server.
@@ -1271,9 +982,9 @@ func (r *LlamaStackDistributionReconciler) reconcileUserConfigMap(ctx context.Co
 		"configMapName", instance.Spec.Server.UserConfig.ConfigMapName,
 		"configMapNamespace", configMapNamespace)
 
-	// Check if the ConfigMap exists
+	// Read via direct client — user ConfigMaps lack operator labels
 	configMap := &corev1.ConfigMap{}
-	err := r.Get(ctx, types.NamespacedName{
+	err := r.directGet(ctx, types.NamespacedName{
 		Name:      instance.Spec.Server.UserConfig.ConfigMapName,
 		Namespace: configMapNamespace,
 	}, configMap)
@@ -1310,9 +1021,9 @@ func (r *LlamaStackDistributionReconciler) reconcileCABundleConfigMap(ctx contex
 		"configMapName", instance.Spec.Server.TLSConfig.CABundle.ConfigMapName,
 		"configMapNamespace", configMapNamespace)
 
-	// Check if the ConfigMap exists
+	// Read via direct client — user CA bundle ConfigMaps lack operator labels
 	configMap := &corev1.ConfigMap{}
-	err := r.Get(ctx, types.NamespacedName{
+	err := r.directGet(ctx, types.NamespacedName{
 		Name:      instance.Spec.Server.TLSConfig.CABundle.ConfigMapName,
 		Namespace: configMapNamespace,
 	}, configMap)
@@ -1369,7 +1080,7 @@ func (r *LlamaStackDistributionReconciler) getConfigMapHash(ctx context.Context,
 	configMapNamespace := r.getUserConfigMapNamespace(instance)
 
 	configMap := &corev1.ConfigMap{}
-	err := r.Get(ctx, types.NamespacedName{
+	err := r.directGet(ctx, types.NamespacedName{
 		Name:      instance.Spec.Server.UserConfig.ConfigMapName,
 		Namespace: configMapNamespace,
 	}, configMap)
@@ -1492,7 +1203,7 @@ func (r *LlamaStackDistributionReconciler) gatherExplicitCABundle(ctx context.Co
 
 	configMapNamespace := r.getCABundleConfigMapNamespace(instance)
 	configMap := &corev1.ConfigMap{}
-	err := r.Get(ctx, types.NamespacedName{
+	err := r.directGet(ctx, types.NamespacedName{
 		Name:      instance.Spec.Server.TLSConfig.CABundle.ConfigMapName,
 		Namespace: configMapNamespace,
 	}, configMap)
@@ -1652,6 +1363,7 @@ func (r *LlamaStackDistributionReconciler) reconcileManagedCABundleConfigMap(ctx
 				"app.kubernetes.io/managed-by": "llama-stack-operator",
 				"app.kubernetes.io/instance":   instance.Name,
 				"app.kubernetes.io/component":  "ca-bundle",
+				WatchLabelKey:                  WatchLabelValue,
 			},
 		},
 		Data: map[string]string{
@@ -1702,7 +1414,7 @@ func (r *LlamaStackDistributionReconciler) detectODHTrustedCABundle(ctx context.
 	logger := log.FromContext(ctx)
 
 	configMap := &corev1.ConfigMap{}
-	err := r.Get(ctx, types.NamespacedName{
+	err := r.directGet(ctx, types.NamespacedName{
 		Name:      odhTrustedCABundleConfigMap,
 		Namespace: instance.Namespace,
 	}, configMap)
@@ -1756,6 +1468,9 @@ func createDefaultConfigMap(configMapName types.NamespacedName) (*corev1.ConfigM
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configMapName.Name,
 			Namespace: configMapName.Namespace,
+			Labels: map[string]string{
+				WatchLabelKey: WatchLabelValue,
+			},
 		},
 		Data: map[string]string{
 			featureflags.FeatureFlagsKey: string(featureFlagsYAML),
@@ -1782,7 +1497,7 @@ func parseFeatureFlags(configMapData map[string]string) (bool, error) {
 
 // NewLlamaStackDistributionReconciler creates a new reconciler with default image mappings.
 func NewLlamaStackDistributionReconciler(ctx context.Context, client client.Client, scheme *runtime.Scheme,
-	clusterInfo *cluster.ClusterInfo) (*LlamaStackDistributionReconciler, error) {
+	clusterInfo *cluster.ClusterInfo, directClient client.Reader) (*LlamaStackDistributionReconciler, error) {
 	// get operator namespace
 	operatorNamespace, err := deploy.GetOperatorNamespace()
 	if err != nil {
@@ -1807,10 +1522,12 @@ func NewLlamaStackDistributionReconciler(ctx context.Context, client client.Clie
 	return &LlamaStackDistributionReconciler{
 		Client:                client,
 		Scheme:                scheme,
+		DirectClient:          directClient,
 		EnableNetworkPolicy:   enableNetworkPolicy,
 		ImageMappingOverrides: imageMappingOverrides,
 		ClusterInfo:           clusterInfo,
 		httpClient:            &http.Client{Timeout: 5 * time.Second},
+		operatorNamespace:     operatorNamespace,
 	}, nil
 }
 
@@ -1838,6 +1555,16 @@ func initializeOperatorConfigMap(ctx context.Context, c client.Client, operatorN
 			configMap.Data[featureflags.FeatureFlagsKey] = newConfigMap.Data[featureflags.FeatureFlagsKey]
 			if err = c.Patch(ctx, configMap, patch); err != nil {
 				return nil, fmt.Errorf("failed to patch ConfigMap: %w", err)
+			}
+		}
+		// Ensure the watch label exists (upgrade path)
+		if configMap.Labels == nil || configMap.Labels[WatchLabelKey] != WatchLabelValue {
+			if configMap.Labels == nil {
+				configMap.Labels = make(map[string]string)
+			}
+			configMap.Labels[WatchLabelKey] = WatchLabelValue
+			if updateErr := c.Update(ctx, configMap); updateErr != nil {
+				return nil, fmt.Errorf("failed to add watch label to operator config ConfigMap: %w", updateErr)
 			}
 		}
 		return configMap, nil
@@ -1928,4 +1655,14 @@ func NewTestReconciler(client client.Client, scheme *runtime.Scheme, clusterInfo
 		EnableNetworkPolicy:   enableNetworkPolicy,
 		ImageMappingOverrides: make(map[string]string),
 	}
+}
+
+// MapConfigMapToReconcileRequests is an exported wrapper for mapConfigMapToReconcileRequests, for testing.
+func (r *LlamaStackDistributionReconciler) MapConfigMapToReconcileRequests(ctx context.Context, obj client.Object) []reconcile.Request {
+	return r.mapConfigMapToReconcileRequests(ctx, obj)
+}
+
+// UserConfigMapPredicate is an exported wrapper for userConfigMapPredicate, for testing.
+func (r *LlamaStackDistributionReconciler) UserConfigMapPredicate() predicate.Funcs {
+	return r.userConfigMapPredicate()
 }

--- a/controllers/llamastackdistribution_controller_ca_whitespace_test.go
+++ b/controllers/llamastackdistribution_controller_ca_whitespace_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// generateTestCertPEM creates a self-signed PEM certificate for testing.
+func generateTestCertPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+	tmpl := x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "test-ca"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+// TestExtractValidCertificates_WhitespaceOnly verifies that extractValidCertificates()
+// correctly handles whitespace-only data, which is a valid state for auto-detected
+// ODH CA bundle keys when no custom CAs are configured.
+func TestExtractValidCertificates_WhitespaceOnly(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		keyName     string
+		expectCerts int
+	}{
+		{
+			name:        "empty string should return success with zero certificates",
+			data:        []byte(""),
+			keyName:     "empty-key",
+			expectCerts: 0,
+		},
+		{
+			name:        "single newline should return success with zero certificates",
+			data:        []byte("\n"),
+			keyName:     "odh-ca-bundle.crt",
+			expectCerts: 0,
+		},
+		{
+			name:        "multiple newlines should return success with zero certificates",
+			data:        []byte("\n\n\n"),
+			keyName:     "test-key",
+			expectCerts: 0,
+		},
+		{
+			name:        "spaces only should return success with zero certificates",
+			data:        []byte("   "),
+			keyName:     "test-key",
+			expectCerts: 0,
+		},
+		{
+			name:        "tabs only should return success with zero certificates",
+			data:        []byte("\t\t\t"),
+			keyName:     "test-key",
+			expectCerts: 0,
+		},
+		{
+			name:        "mixed whitespace should return success with zero certificates",
+			data:        []byte("  \n\t  \n  "),
+			keyName:     "test-key",
+			expectCerts: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			certs, size, count, err := extractValidCertificates(tt.data, tt.keyName)
+			require.NoError(t, err, "expected no error for test case: %s", tt.name)
+			require.Equal(t, tt.expectCerts, count, "certificate count should match expected value")
+			require.Nil(t, certs, "certificates should be nil for zero count")
+			require.Equal(t, 0, size, "size should be 0 for zero certificates")
+		})
+	}
+}
+
+// TestExtractValidCertificates_InvalidPEM verifies that invalid PEM data returns an error.
+func TestExtractValidCertificates_InvalidPEM(t *testing.T) {
+	certs, size, count, err := extractValidCertificates([]byte("not a certificate"), "invalid-key")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to find valid certificates")
+	require.Nil(t, certs)
+	require.Zero(t, size)
+	require.Zero(t, count)
+}
+
+// TestExtractValidCertificates_ValidCerts verifies that valid PEM certificates
+// are correctly extracted, including when surrounded by whitespace.
+func TestExtractValidCertificates_ValidCerts(t *testing.T) {
+	certPEM := generateTestCertPEM(t)
+
+	t.Run("single certificate", func(t *testing.T) {
+		certs, size, count, err := extractValidCertificates([]byte(certPEM), "valid-cert")
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+		require.NotNil(t, certs)
+		require.Positive(t, size)
+		require.Len(t, certs, 1)
+	})
+
+	t.Run("certificate with surrounding whitespace", func(t *testing.T) {
+		data := []byte("\n\n" + certPEM + "\n\n")
+		certs, size, count, err := extractValidCertificates(data, "cert-with-whitespace")
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+		require.NotNil(t, certs)
+		require.Positive(t, size)
+		require.Len(t, certs, 1)
+	})
+}
+
+// TestExtractValidCertificates_MultipleValidCertificates tests that multiple valid
+// certificates are correctly extracted and concatenated.
+func TestExtractValidCertificates_MultipleValidCertificates(t *testing.T) {
+	cert1 := generateTestCertPEM(t)
+	cert2 := generateTestCertPEM(t)
+
+	data := []byte(cert1 + "\n" + cert2)
+
+	certs, size, count, err := extractValidCertificates(data, "multi-cert-key")
+
+	require.NoError(t, err, "should successfully extract multiple certificates")
+	require.Equal(t, 2, count, "should find 2 certificates")
+	require.Len(t, certs, 2, "certificates slice should contain 2 items")
+	require.Positive(t, size, "total size should be greater than 0")
+}

--- a/controllers/llamastackdistribution_controller_test.go
+++ b/controllers/llamastackdistribution_controller_test.go
@@ -23,7 +23,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // testenvNamespaceCounter is used to generate unique namespace names for test isolation.
@@ -653,6 +655,8 @@ func TestManagedCABundleConfigMap(t *testing.T) {
 		require.Equal(t, "llama-stack-operator", managedConfigMap.Labels["app.kubernetes.io/managed-by"])
 		require.Equal(t, instance.Name, managedConfigMap.Labels["app.kubernetes.io/instance"])
 		require.Equal(t, "ca-bundle", managedConfigMap.Labels["app.kubernetes.io/component"])
+		require.Equal(t, controllers.WatchLabelValue, managedConfigMap.Labels[controllers.WatchLabelKey],
+			"managed CA bundle ConfigMap should have the watch label")
 	})
 
 	t.Run("updates managed ConfigMap when source changes", func(t *testing.T) {
@@ -889,6 +893,7 @@ func TestNewLlamaStackDistributionReconciler_WithImageOverrides(t *testing.T) {
 		k8sClient,
 		scheme.Scheme,
 		clusterInfo,
+		k8sClient,
 	)
 
 	// Assertions
@@ -942,6 +947,7 @@ func TestConfigMapUpdateTriggersReconciliation(t *testing.T) {
 		k8sClient,
 		scheme.Scheme,
 		clusterInfo,
+		k8sClient,
 	)
 	require.NoError(t, err)
 
@@ -958,25 +964,21 @@ func TestConfigMapUpdateTriggersReconciliation(t *testing.T) {
 	require.Equal(t, "default-starter-image", initialImage,
 		"Initial deployment should use distribution image")
 
+	// Re-fetch the ConfigMap to get the latest resource version (initializeOperatorConfigMap
+	// may have updated it to add the watch label).
 	require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
 		Name:      configMap.Name,
 		Namespace: configMap.Namespace,
 	}, configMap))
+
 	// Update ConfigMap with new overrides
 	configMap.Data["image-overrides"] = "starter: quay.io/custom/llama-stack:starter"
 	require.NoError(t, k8sClient.Update(t.Context(), configMap))
 
-	// Simulate ConfigMap update by recreating reconciler (in real scenario this would be triggered by watch)
-	updatedReconciler, err := controllers.NewLlamaStackDistributionReconciler(
-		t.Context(),
-		k8sClient,
-		scheme.Scheme,
-		clusterInfo,
-	)
-	require.NoError(t, err)
-
-	// Reconcile with updated overrides
-	_, err = updatedReconciler.Reconcile(t.Context(), ctrl.Request{
+	// Reconcile with the same reconciler instance. refreshOperatorConfig (called
+	// at the start of Reconcile) reads the updated ConfigMap via the direct API
+	// client, so the new image override is picked up without recreating the reconciler.
+	_, err = reconciler.Reconcile(t.Context(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace},
 	})
 	require.NoError(t, err)
@@ -987,4 +989,266 @@ func TestConfigMapUpdateTriggersReconciliation(t *testing.T) {
 		deployment, func() bool {
 			return deployment.Spec.Template.Spec.Containers[0].Image == "quay.io/custom/llama-stack:starter"
 		}, "Deployment should be updated with new image")
+}
+
+func TestRefreshOperatorConfigPicksUpChanges(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	namespace := createTestNamespace(t, "test-refresh-config")
+	operatorNamespace := createTestNamespace(t, "llama-stack-k8s-operator-system")
+	t.Setenv("OPERATOR_NAMESPACE", operatorNamespace.Name)
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "llama-stack-operator-config",
+			Namespace: operatorNamespace.Name,
+		},
+		Data: map[string]string{
+			"featureFlags": `enableNetworkPolicy:
+    enabled: false`,
+		},
+	}
+	require.NoError(t, k8sClient.Create(t.Context(), configMap))
+
+	instance := NewDistributionBuilder().
+		WithName("test-refresh-config").
+		WithNamespace(namespace.Name).
+		WithDistribution("starter").
+		Build()
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+
+	clusterInfo := &cluster.ClusterInfo{
+		OperatorNamespace:  operatorNamespace.Name,
+		DistributionImages: map[string]string{"starter": "default-starter-image"},
+	}
+
+	reconciler, err := controllers.NewLlamaStackDistributionReconciler(
+		t.Context(),
+		k8sClient,
+		scheme.Scheme,
+		clusterInfo,
+		k8sClient,
+	)
+	require.NoError(t, err)
+
+	// Initial reconcile creates resources.
+	_, err = reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace},
+	})
+	require.NoError(t, err)
+
+	// Verify network policy is NOT created (feature disabled).
+	networkPolicy := &networkingv1.NetworkPolicy{}
+	npName := instance.Name + "-network-policy"
+	err = k8sClient.Get(t.Context(), types.NamespacedName{Name: npName, Namespace: instance.Namespace}, networkPolicy)
+	require.True(t, apierrors.IsNotFound(err), "NetworkPolicy should not exist when feature is disabled")
+
+	// Re-fetch the ConfigMap to get the latest resource version (initializeOperatorConfigMap
+	// may have updated it to add the watch label).
+	require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
+		Name:      configMap.Name,
+		Namespace: configMap.Namespace,
+	}, configMap))
+
+	// Enable network policy via operator config update.
+	configMap.Data["featureFlags"] = `enableNetworkPolicy:
+    enabled: true`
+	require.NoError(t, k8sClient.Update(t.Context(), configMap))
+
+	// Reconcile again -- refreshOperatorConfig picks up the new flag.
+	_, err = reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace},
+	})
+	require.NoError(t, err)
+
+	// Verify network policy IS created now.
+	waitForResource(t, k8sClient, instance.Namespace, npName, networkPolicy)
+}
+
+func TestReconcileRequeuesAfterSuccess(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	namespace := createTestNamespace(t, "test-requeue")
+	operatorNamespace := createTestNamespace(t, "llama-stack-k8s-operator-system")
+	t.Setenv("OPERATOR_NAMESPACE", operatorNamespace.Name)
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "llama-stack-operator-config",
+			Namespace: operatorNamespace.Name,
+		},
+		Data: map[string]string{
+			"featureFlags": `enableNetworkPolicy:
+    enabled: false`,
+		},
+	}
+	require.NoError(t, k8sClient.Create(t.Context(), configMap))
+
+	instance := NewDistributionBuilder().
+		WithName("test-requeue").
+		WithNamespace(namespace.Name).
+		WithDistribution("starter").
+		Build()
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+
+	clusterInfo := &cluster.ClusterInfo{
+		OperatorNamespace:  operatorNamespace.Name,
+		DistributionImages: map[string]string{"starter": "default-starter-image"},
+	}
+
+	reconciler, err := controllers.NewLlamaStackDistributionReconciler(
+		t.Context(),
+		k8sClient,
+		scheme.Scheme,
+		clusterInfo,
+		k8sClient,
+	)
+	require.NoError(t, err)
+
+	result, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace},
+	})
+	require.NoError(t, err)
+
+	// In test envs, deployment never becomes ready (no kubelet), so the instance
+	// stays in Initializing phase which requeues after 10s. Verify that a
+	// successful reconciliation always schedules a requeue (not zero).
+	// In test env the deployment stays in Initializing phase (10s requeue).
+	// The Ready path returns 5m. Either way, requeue must be scheduled.
+	require.Positive(t, result.RequeueAfter,
+		"Successful reconciliation should always schedule a requeue")
+	require.Equal(t, 10*time.Second, result.RequeueAfter,
+		"Initializing phase should requeue after 10 seconds")
+}
+
+func TestMapConfigMapToReconcileRequests(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	namespace := createTestNamespace(t, "test-cm-mapping")
+
+	// Create a user ConfigMap with the watch label.
+	userConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-config",
+			Namespace: namespace.Name,
+			Labels: map[string]string{
+				controllers.WatchLabelKey: controllers.WatchLabelValue,
+			},
+		},
+		Data: map[string]string{
+			"config.yaml": "version: '2'\nimage_name: ollama",
+		},
+	}
+	require.NoError(t, k8sClient.Create(t.Context(), userConfigMap))
+
+	// Create an instance that references this ConfigMap.
+	instance := NewDistributionBuilder().
+		WithName("test-cm-mapping").
+		WithNamespace(namespace.Name).
+		WithUserConfig(userConfigMap.Name).
+		Build()
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() { _ = k8sClient.Delete(t.Context(), instance) })
+
+	reconciler := createTestReconciler()
+
+	// Act: call the handler with the user ConfigMap.
+	requests := reconciler.MapConfigMapToReconcileRequests(t.Context(), userConfigMap)
+
+	// Assert: should return a request for the referencing instance.
+	require.Len(t, requests, 1, "should map to exactly one CR")
+	require.Equal(t, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		},
+	}, requests[0])
+}
+
+func TestMapConfigMapToReconcileRequests_SkipsManagedConfigMaps(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	namespace := createTestNamespace(t, "test-cm-skip-managed")
+
+	// Create an operator-managed ConfigMap.
+	managedConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "managed-cm",
+			Namespace: namespace.Name,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "llama-stack-operator",
+				controllers.WatchLabelKey:      controllers.WatchLabelValue,
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(t.Context(), managedConfigMap))
+
+	reconciler := createTestReconciler()
+
+	// Act: call the handler with the managed ConfigMap.
+	requests := reconciler.MapConfigMapToReconcileRequests(t.Context(), managedConfigMap)
+
+	// Assert: should return no requests (managed CMs are handled by Owns).
+	require.Empty(t, requests, "managed ConfigMaps should be skipped")
+}
+
+func TestUserConfigMapPredicate(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	reconciler := createTestReconciler()
+	pred := reconciler.UserConfigMapPredicate()
+
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		expected bool
+	}{
+		{
+			name: "watch-labeled user ConfigMap is accepted",
+			labels: map[string]string{
+				controllers.WatchLabelKey: controllers.WatchLabelValue,
+			},
+			expected: true,
+		},
+		{
+			name: "operator-managed ConfigMap is rejected even with watch label",
+			labels: map[string]string{
+				"app.kubernetes.io/managed-by": "llama-stack-operator",
+				controllers.WatchLabelKey:      controllers.WatchLabelValue,
+			},
+			expected: false,
+		},
+		{
+			name:     "unlabeled ConfigMap is rejected",
+			labels:   nil,
+			expected: false,
+		},
+		{
+			name: "ConfigMap without watch label is rejected",
+			labels: map[string]string{
+				"some-other-label": "value",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-cm",
+					Labels: tt.labels,
+				},
+			}
+
+			result := pred.Create(event.CreateEvent{Object: cm})
+			require.Equal(t, tt.expected, result, "Create predicate")
+
+			result = pred.Update(event.UpdateEvent{ObjectNew: cm, ObjectOld: cm})
+			require.Equal(t, tt.expected, result, "Update predicate")
+
+			result = pred.Delete(event.DeleteEvent{Object: cm})
+			require.Equal(t, tt.expected, result, "Delete predicate")
+		})
+	}
 }

--- a/controllers/manifests/base/kustomization.yaml
+++ b/controllers/manifests/base/kustomization.yaml
@@ -16,3 +16,4 @@ labels:
   pairs:
     app.kubernetes.io/managed-by: llama-stack-operator
     app.kubernetes.io/part-of: llama-stack
+    llamastack.io/watch: "true"

--- a/controllers/manifests/base/pdb.yaml
+++ b/controllers/manifests/base/pdb.yaml
@@ -6,7 +6,7 @@ metadata:
     app: llama-stack
     app.kubernetes.io/instance: ""
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: llama-stack

--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -662,8 +662,10 @@ func buildPodDisruptionBudgetSpec(instance *llamav1alpha1.LlamaStackDistribution
 		spec.MinAvailable = copyIntOrString(instance.Spec.Server.PodDisruptionBudget.MinAvailable)
 		spec.MaxUnavailable = copyIntOrString(instance.Spec.Server.PodDisruptionBudget.MaxUnavailable)
 	} else {
-		minAvailable := intstr.FromInt(1)
-		spec.MinAvailable = &minAvailable
+		// Fix for RHAIENG-3783: Use maxUnavailable instead of minAvailable
+		// to avoid allowedDisruptions=0 with single-replica deployments
+		maxUnavailable := intstr.FromInt(1)
+		spec.MaxUnavailable = &maxUnavailable
 	}
 
 	return spec

--- a/controllers/resource_helper_test.go
+++ b/controllers/resource_helper_test.go
@@ -957,9 +957,9 @@ func TestBuildPodDisruptionBudgetSpec(t *testing.T) {
 
 		spec := buildPodDisruptionBudgetSpec(instance)
 		require.NotNil(t, spec)
-		require.NotNil(t, spec.MinAvailable)
-		assert.Equal(t, 1, spec.MinAvailable.IntValue())
-		assert.Nil(t, spec.MaxUnavailable)
+		require.NotNil(t, spec.MaxUnavailable)
+		assert.Equal(t, 1, spec.MaxUnavailable.IntValue())
+		assert.Nil(t, spec.MinAvailable)
 	})
 
 	t.Run("respects custom overrides", func(t *testing.T) {

--- a/distributions.json
+++ b/distributions.json
@@ -1,6 +1,6 @@
 {
-  "starter": "docker.io/llamastack/distribution-starter:0.6.0",
-  "remote-vllm": "docker.io/llamastack/distribution-remote-vllm:0.6.0",
-  "meta-reference-gpu": "docker.io/llamastack/distribution-meta-reference-gpu:0.6.0",
-  "postgres-demo": "docker.io/llamastack/distribution-postgres-demo:0.6.0"
+  "starter": "docker.io/llamastack/distribution-starter:0.7.1",
+  "remote-vllm": "docker.io/llamastack/distribution-remote-vllm:0.7.1",
+  "meta-reference-gpu": "docker.io/llamastack/distribution-meta-reference-gpu:0.7.1",
+  "postgres-demo": "docker.io/llamastack/distribution-postgres-demo:0.7.1"
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/llamastack/llama-stack-k8s-operator
 
-go 1.25.5
+go 1.25.8
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/main.go
+++ b/main.go
@@ -26,10 +26,17 @@ import (
 	"github.com/llamastack/llama-stack-k8s-operator/controllers"
 	"github.com/llamastack/llama-stack-k8s-operator/pkg/cluster"
 	"go.uber.org/zap/zapcore"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -58,8 +65,8 @@ func init() { //nolint:gochecknoinits
 	//+kubebuilder:scaffold:scheme
 }
 
-func setupReconciler(ctx context.Context, cli client.Client, mgr ctrl.Manager, clusterInfo *cluster.ClusterInfo) error {
-	reconciler, err := controllers.NewLlamaStackDistributionReconciler(ctx, cli, scheme, clusterInfo)
+func setupReconciler(ctx context.Context, cli client.Client, mgr ctrl.Manager, clusterInfo *cluster.ClusterInfo, directClient client.Reader) error {
+	reconciler, err := controllers.NewLlamaStackDistributionReconciler(ctx, cli, scheme, clusterInfo, directClient)
 	if err != nil {
 		return fmt.Errorf("failed to create reconciler: %w", err)
 	}
@@ -67,6 +74,31 @@ func setupReconciler(ctx context.Context, cli client.Client, mgr ctrl.Manager, c
 		return fmt.Errorf("failed to create controller: %w", err)
 	}
 	return nil
+}
+
+func newCacheOptions() cache.Options {
+	managedBySelector := labels.SelectorFromSet(labels.Set{
+		"app.kubernetes.io/managed-by": "llama-stack-operator",
+	})
+	managedByFilter := cache.ByObject{Label: managedBySelector}
+
+	return cache.Options{
+		DefaultTransform: cache.TransformStripManagedFields(),
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.ConfigMap{}: {
+				Label: labels.SelectorFromSet(labels.Set{
+					controllers.WatchLabelKey: controllers.WatchLabelValue,
+				}),
+			},
+			&appsv1.Deployment{}:                     managedByFilter,
+			&policyv1.PodDisruptionBudget{}:          managedByFilter,
+			&autoscalingv2.HorizontalPodAutoscaler{}: managedByFilter,
+			&corev1.Service{}:                        managedByFilter,
+			&networkingv1.NetworkPolicy{}:            managedByFilter,
+			&networkingv1.Ingress{}:                  managedByFilter,
+			&corev1.PersistentVolumeClaim{}:          managedByFilter,
+		},
+	}
 }
 
 func setupHealthChecks(mgr ctrl.Manager) error {
@@ -104,6 +136,7 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                     scheme,
 		Metrics:                    metricsserver.Options{BindAddress: metricsAddr},
+		Cache:                      newCacheOptions(),
 		HealthProbeBindAddress:     probeAddr,
 		LeaderElection:             enableLeaderElection,
 		LeaderElectionID:           "54e06e98.llamastack.io",
@@ -152,7 +185,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := setupReconciler(ctx, setupClient, mgr, clusterInfo); err != nil {
+	if err := setupReconciler(ctx, setupClient, mgr, clusterInfo, setupClient); err != nil {
 		setupLog.Error(err, "failed to set up reconciler")
 		os.Exit(1)
 	}

--- a/pkg/deploy/kustomizer.go
+++ b/pkg/deploy/kustomizer.go
@@ -310,7 +310,20 @@ func getFieldMappings(ownerInstance *llamav1alpha1.LlamaStackDistribution) []plu
 	storageSize := getStorageSize(ownerInstance)
 	instanceLabelPath := "/app.kubernetes.io~1instance"
 
-	return buildFieldMappings(instanceName, instanceNamespace, serviceAccountName, servicePort, storageSize, instanceLabelPath, ownerInstance.Spec.Replicas)
+	mappings := buildFieldMappings(instanceName, instanceNamespace, serviceAccountName, servicePort, storageSize, instanceLabelPath, ownerInstance.Spec.Replicas)
+
+	// When persistent storage is configured, use Recreate strategy to avoid
+	// RWO PVC multi-attach deadlock during rolling updates
+	if ownerInstance.Spec.Server.Storage != nil {
+		mappings = append(mappings, plugins.FieldMapping{
+			SourceValue:       "Recreate",
+			TargetField:       "/spec/strategy/type",
+			TargetKind:        "Deployment",
+			CreateIfNotExists: true,
+		})
+	}
+
+	return mappings
 }
 
 // buildFieldMappings constructs the field mappings array.

--- a/pkg/deploy/kustomizer.go
+++ b/pkg/deploy/kustomizer.go
@@ -12,7 +12,9 @@ import (
 	llamav1alpha1 "github.com/llamastack/llama-stack-k8s-operator/api/v1alpha1"
 	"github.com/llamastack/llama-stack-k8s-operator/pkg/compare"
 	"github.com/llamastack/llama-stack-k8s-operator/pkg/deploy/plugins"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -188,11 +190,14 @@ func patchResource(ctx context.Context, cli client.Client, desired, existing *un
 			return fmt.Errorf("failed to validate resource mutations while patching: %w", err)
 		}
 	case deploymentKind:
-		// Check for legacy CA bundle volumes and use full replacement to avoid SSA conflicts
-		if hasLegacyCABundleVolumes(ctx, existing) {
-			logger.Info("Detected legacy CA bundle volumes, using full replacement instead of SSA",
+		// Some volume changes cannot be handled by SSA because the volumes were originally
+		// created via cli.Create (no SSA field manager tracking), so SSA cannot remove
+		// unowned fields. Fall back to full replacement in these cases.
+		if reason := deploymentNeedsFullReplacement(ctx, desired, existing); reason != "" {
+			logger.Info("Using full replacement instead of SSA for Deployment",
 				"deployment", existing.GetName(),
-				"namespace", existing.GetNamespace())
+				"namespace", existing.GetNamespace(),
+				"reason", reason)
 			desired.SetResourceVersion(existing.GetResourceVersion())
 			return cli.Update(ctx, desired)
 		}
@@ -684,6 +689,16 @@ func FilterExcludeKinds(resMap *resmap.ResMap, kindsToExclude []string) (*resmap
 	return &filteredResMap, nil
 }
 
+// hasVolume reports whether a volume with the given name exists in the slice.
+func hasVolume(volumes []corev1.Volume, name string) bool {
+	for _, vol := range volumes {
+		if vol.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // hasLegacyCABundleVolumes detects if a deployment has legacy CA bundle volumes
 // from the old operator that used emptyDir + ConfigMap pattern.
 func hasLegacyCABundleVolumes(ctx context.Context, deployment *unstructured.Unstructured) bool {
@@ -722,6 +737,42 @@ func hasLegacyCABundleVolumes(ctx context.Context, deployment *unstructured.Unst
 	}
 
 	return false
+}
+
+// hasStaleUserConfigVolume returns true when the existing Deployment has a "user-config"
+// volume that is absent from the desired Deployment spec. This happens when
+// spec.server.userConfig is removed from the LLSD resource: the volume persists because
+// it was applied via cli.Create (no SSA field manager tracking), so a subsequent SSA patch
+// cannot remove it. Using cli.Update instead performs a full spec replacement.
+func hasStaleUserConfigVolume(desired, existing *appsv1.Deployment) bool {
+	return hasVolume(existing.Spec.Template.Spec.Volumes, "user-config") &&
+		!hasVolume(desired.Spec.Template.Spec.Volumes, "user-config")
+}
+
+// deploymentNeedsFullReplacement returns a non-empty reason string when the Deployment
+// must be updated via cli.Update (full replacement) instead of SSA. This is necessary
+// when volumes exist in the live Deployment that SSA cannot remove because they were
+// created by a different field manager (e.g. the initial cli.Create).
+func deploymentNeedsFullReplacement(ctx context.Context, desired, existing *unstructured.Unstructured) string {
+	logger := log.FromContext(ctx)
+
+	if hasLegacyCABundleVolumes(ctx, existing) {
+		return "legacy CA bundle volumes detected"
+	}
+
+	var existingDep, desiredDep appsv1.Deployment
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(existing.Object, &existingDep); err != nil {
+		logger.Error(err, "failed to convert existing Deployment, skipping stale-volume check")
+		return ""
+	}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(desired.Object, &desiredDep); err != nil {
+		logger.Error(err, "failed to convert desired Deployment, skipping stale-volume check")
+		return ""
+	}
+	if hasStaleUserConfigVolume(&desiredDep, &existingDep) {
+		return "stale user-config volume detected"
+	}
+	return ""
 }
 
 // CheckClusterRoleExists checks if a RoleBinding should be skipped due to missing SCC ClusterRole.

--- a/pkg/deploy/kustomizer_test.go
+++ b/pkg/deploy/kustomizer_test.go
@@ -740,6 +740,166 @@ func TestHasLegacyCABundleVolumes(t *testing.T) {
 	})
 }
 
+// TestHasStaleUserConfigVolume tests detection of a stale user-config volume
+// (present in existing Deployment but absent from desired).
+func TestHasStaleUserConfigVolume(t *testing.T) {
+	makeDeployment := func(volumes ...corev1.Volume) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Volumes: volumes},
+				},
+			},
+		}
+	}
+
+	userConfigVol := corev1.Volume{
+		Name: "user-config",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "my-config"},
+			},
+		},
+	}
+	storageVol := corev1.Volume{
+		Name:         "lls-storage",
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	}
+
+	t.Run("returns true when existing has user-config and desired does not", func(t *testing.T) {
+		existing := makeDeployment(storageVol, userConfigVol)
+		desired := makeDeployment(storageVol)
+		require.True(t, hasStaleUserConfigVolume(desired, existing))
+	})
+
+	t.Run("returns false when both existing and desired have user-config", func(t *testing.T) {
+		existing := makeDeployment(storageVol, userConfigVol)
+		desired := makeDeployment(storageVol, userConfigVol)
+		require.False(t, hasStaleUserConfigVolume(desired, existing))
+	})
+
+	t.Run("returns false when neither has user-config", func(t *testing.T) {
+		existing := makeDeployment(storageVol)
+		desired := makeDeployment(storageVol)
+		require.False(t, hasStaleUserConfigVolume(desired, existing))
+	})
+
+	t.Run("returns false when only desired has user-config", func(t *testing.T) {
+		existing := makeDeployment(storageVol)
+		desired := makeDeployment(storageVol, userConfigVol)
+		require.False(t, hasStaleUserConfigVolume(desired, existing))
+	})
+
+	t.Run("returns false when no volumes present in either", func(t *testing.T) {
+		existing := makeDeployment()
+		desired := makeDeployment()
+		require.False(t, hasStaleUserConfigVolume(desired, existing))
+	})
+}
+
+// TestUserConfigVolumeRemoval tests that removing spec.server.userConfig from the LLSD
+// causes the "user-config" volume to be removed from the Deployment.
+func TestUserConfigVolumeRemoval(t *testing.T) {
+	ctx, testNs, owner := setupApplyResourcesTest(t, "userconfig-removal")
+
+	// Create an existing Deployment that has a user-config volume (simulates operator
+	// creating the Deployment via cli.Create when userConfig was set, without SSA
+	// field manager tracking).
+	existingDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: testNs,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(owner, owner.GroupVersionKind()),
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr(int32(1)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "test:v1"},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "lls-storage",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						// This volume was set when userConfig was configured;
+						// it should be removed when userConfig is cleared.
+						{
+							Name: "user-config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "my-llama-config",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, existingDeployment))
+
+	// Desired Deployment reflects the LLSD after userConfig has been removed —
+	// only the storage volume remains.
+	desiredDeployment := newTestResource(t, "apps/v1", "Deployment", "test-deployment", testNs, map[string]any{
+		"replicas": int32(1),
+		"selector": map[string]any{
+			"matchLabels": map[string]any{"app": "test"},
+		},
+		"template": map[string]any{
+			"metadata": map[string]any{
+				"labels": map[string]any{"app": "test"},
+			},
+			"spec": map[string]any{
+				"containers": []any{
+					map[string]any{"name": "main", "image": "test:v2"},
+				},
+				"volumes": []any{
+					map[string]any{
+						"name":     "lls-storage",
+						"emptyDir": map[string]any{},
+					},
+				},
+			},
+		},
+	})
+
+	resMap := resmap.New()
+	require.NoError(t, resMap.Append(desiredDeployment))
+
+	require.NoError(t, ApplyResources(ctx, k8sClient, scheme.Scheme, owner, &resMap))
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "test-deployment", Namespace: testNs}, updated))
+
+	// Verify the user-config volume was removed.
+	for _, vol := range updated.Spec.Template.Spec.Volumes {
+		require.NotEqual(t, "user-config", vol.Name, "stale user-config volume should have been removed from the Deployment")
+	}
+	// Verify the storage volume still exists.
+	found := false
+	for _, vol := range updated.Spec.Template.Spec.Volumes {
+		if vol.Name == "lls-storage" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "lls-storage volume should still be present")
+}
+
 // TestLegacyCABundleUpgrade tests that deployments with legacy CA bundle volumes
 // are replaced instead of patched to avoid SSA conflicts.
 func TestLegacyCABundleUpgrade(t *testing.T) {
@@ -889,23 +1049,6 @@ func TestLegacyCABundleUpgrade(t *testing.T) {
 	require.Empty(t, updatedDeployment.Spec.Template.Spec.InitContainers, "legacy init containers should be removed")
 }
 
-// resourceToUnstructured converts a kustomize resource to an unstructured object.
-func resourceToUnstructured(t *testing.T, res *kresource.Resource) (*unstructured.Unstructured, error) {
-	t.Helper()
-
-	yamlBytes, err := res.AsYAML()
-	if err != nil {
-		return nil, err
-	}
-
-	u := &unstructured.Unstructured{}
-	if err := yaml.Unmarshal(yamlBytes, u); err != nil {
-		return nil, err
-	}
-
-	return u, nil
-}
-
 // ptr is a helper function to get a pointer to a value.
 func ptr[T any](v T) *T {
 	return &v
@@ -954,4 +1097,21 @@ func TestGetFieldMappings_RecreateStrategyWithStorage(t *testing.T) {
 			}
 		}
 	})
+}
+
+// resourceToUnstructured converts a kustomize resource to an unstructured object.
+func resourceToUnstructured(t *testing.T, res *kresource.Resource) (*unstructured.Unstructured, error) {
+	t.Helper()
+
+	yamlBytes, err := res.AsYAML()
+	if err != nil {
+		return nil, err
+	}
+
+	u := &unstructured.Unstructured{}
+	if err := yaml.Unmarshal(yamlBytes, u); err != nil {
+		return nil, err
+	}
+
+	return u, nil
 }

--- a/pkg/deploy/kustomizer_test.go
+++ b/pkg/deploy/kustomizer_test.go
@@ -910,3 +910,48 @@ func resourceToUnstructured(t *testing.T, res *kresource.Resource) (*unstructure
 func ptr[T any](v T) *T {
 	return &v
 }
+
+func TestGetFieldMappings_RecreateStrategyWithStorage(t *testing.T) {
+	t.Run("includes Recreate strategy when storage is configured", func(t *testing.T) {
+		owner := &llamav1alpha1.LlamaStackDistribution{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: llamav1alpha1.LlamaStackDistributionSpec{
+				Replicas: 1,
+				Server: llamav1alpha1.ServerSpec{
+					Storage: &llamav1alpha1.StorageSpec{},
+				},
+			},
+		}
+
+		mappings := getFieldMappings(owner)
+
+		var found bool
+		for _, m := range mappings {
+			if m.TargetField == "/spec/strategy/type" && m.TargetKind == "Deployment" {
+				assert.Equal(t, "Recreate", m.SourceValue)
+				assert.True(t, m.CreateIfNotExists)
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "should include Recreate strategy mapping when storage is configured")
+	})
+
+	t.Run("does not include strategy when storage is nil", func(t *testing.T) {
+		owner := &llamav1alpha1.LlamaStackDistribution{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: llamav1alpha1.LlamaStackDistributionSpec{
+				Replicas: 1,
+				Server:   llamav1alpha1.ServerSpec{},
+			},
+		}
+
+		mappings := getFieldMappings(owner)
+
+		for _, m := range mappings {
+			if m.TargetField == "/spec/strategy/type" {
+				t.Fatal("should not include strategy mapping when storage is nil")
+			}
+		}
+	})
+}

--- a/pkg/deploy/suite_test.go
+++ b/pkg/deploy/suite_test.go
@@ -72,7 +72,7 @@ func newTestResource(t *testing.T, apiVersion, kind, name, namespace string, con
 	}
 
 	switch kind {
-	case "Deployment":
+	case deploymentKind:
 		baseDeploymentContent := map[string]any{
 			"selector": map[string]any{
 				"matchLabels": map[string]any{"app": name},

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -3206,6 +3206,8 @@ spec:
         command:
         - /manager
         env:
+        - name: GOMEMLIMIT
+          value: 800MiB
         - name: OPERATOR_VERSION
           value: latest
         - name: RELATED_IMAGE_RH_DISTRIBUTION

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -3263,7 +3263,7 @@ metadata:
   name: llama-stack-k8s-operator-controller-manager-pdb
   namespace: llama-stack-k8s-operator-system
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: llama-stack-k8s-operator

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -3209,10 +3209,10 @@ spec:
         - name: GOMEMLIMIT
           value: 800MiB
         - name: OPERATOR_VERSION
-          value: latest
+          value: 0.9.0
         - name: RELATED_IMAGE_RH_DISTRIBUTION
           value: ""
-        image: quay.io/llamastack/llama-stack-k8s-operator:latest
+        image: quay.io/llamastack/llama-stack-k8s-operator:v0.9.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/specs/002-operator-generated-config/quickstart.md
+++ b/specs/002-operator-generated-config/quickstart.md
@@ -226,7 +226,7 @@ spec:
       size: "20Gi"
       mountPath: "/.llama"
     podDisruptionBudget:
-      minAvailable: 1
+      maxUnavailable: 1
 ```
 
 ## Example 7: Full ConfigMap Override

--- a/specs/002-operator-generated-config/spec.md
+++ b/specs/002-operator-generated-config/spec.md
@@ -462,7 +462,7 @@ spec:
       size: "10Gi"
       mountPath: "/.llama"
     podDisruptionBudget:
-      minAvailable: 1
+      maxUnavailable: 1
     topologySpreadConstraints: []
     overrides:
       serviceAccountName: "custom-sa"

--- a/tests/e2e/rollout_test.go
+++ b/tests/e2e/rollout_test.go
@@ -1,0 +1,305 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/llamastack/llama-stack-k8s-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	rolloutTestNS           = "llama-stack-rollout-test"
+	rolloutTestTimeout      = 5 * time.Minute
+	rolloutCRName           = "rollout-test"
+	ollamaInferenceModelEnv = "OLLAMA_INFERENCE_MODEL"
+)
+
+// TestRolloutWithStorage verifies that updating a LlamaStackDistribution
+// with persistent storage completes without RWO PVC multi-attach deadlock.
+// Requires a multi-node cluster. Cordons the initial pod's node to force
+// cross-node scheduling, guaranteeing the RWO conflict if strategy is wrong.
+func TestRolloutWithStorage(t *testing.T) {
+	if TestOpts.SkipCreation {
+		t.Skip("Skipping rollout test suite")
+	}
+
+	nodeList := &corev1.NodeList{}
+	require.NoError(t, TestEnv.Client.List(TestEnv.Ctx, nodeList))
+	if len(nodeList.Items) <= 1 {
+		t.Skip("Skipping: requires multi-node cluster to test RWO PVC rollout behavior")
+	}
+
+	t.Run("should create test namespace", func(t *testing.T) {
+		testCreateRolloutNamespace(t)
+	})
+
+	t.Run("should create distribution with storage", func(t *testing.T) {
+		testCreateDistributionWithStorage(t)
+	})
+
+	t.Run("should use Recreate strategy when storage is configured", func(t *testing.T) {
+		testDeploymentStrategy(t)
+	})
+
+	t.Run("should complete rollout after env var update", func(t *testing.T) {
+		testRolloutAfterEnvVarUpdate(t)
+	})
+
+	t.Run("should have no FailedAttachVolume events", func(t *testing.T) {
+		testNoFailedAttachVolumeEvents(t)
+	})
+
+	t.Run("should cleanup rollout test resources", func(t *testing.T) {
+		testRolloutCleanup(t)
+	})
+}
+
+func testCreateRolloutNamespace(t *testing.T) {
+	t.Helper()
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: rolloutTestNS},
+	}
+	err := TestEnv.Client.Create(TestEnv.Ctx, ns)
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		require.NoError(t, err)
+	}
+}
+
+func testCreateDistributionWithStorage(t *testing.T) {
+	t.Helper()
+
+	cr := &v1alpha1.LlamaStackDistribution{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rolloutCRName,
+			Namespace: rolloutTestNS,
+		},
+		Spec: v1alpha1.LlamaStackDistributionSpec{
+			Replicas: 1,
+			Server: v1alpha1.ServerSpec{
+				Distribution: v1alpha1.DistributionType{
+					Name: starterDistType,
+				},
+				ContainerSpec: v1alpha1.ContainerSpec{
+					Name: "llama-stack",
+					Env: []corev1.EnvVar{
+						{Name: ollamaInferenceModelEnv, Value: "llama3.2:1b"},
+						{Name: "OLLAMA_URL", Value: "http://ollama-server-service.ollama-dist.svc.cluster.local:11434"},
+					},
+				},
+				Storage: &v1alpha1.StorageSpec{},
+			},
+		},
+	}
+
+	t.Log("Creating LlamaStackDistribution with persistent storage")
+	require.NoError(t, TestEnv.Client.Create(TestEnv.Ctx, cr))
+
+	err := EnsureResourceReady(t, TestEnv, schema.GroupVersionKind{
+		Group: "apps", Version: "v1", Kind: "Deployment",
+	}, rolloutCRName, rolloutTestNS, rolloutTestTimeout, isDeploymentReady)
+	requireNoErrorWithDebugging(t, TestEnv, err,
+		"Initial deployment should become ready", rolloutTestNS, rolloutCRName)
+
+	err = WaitForPodsReady(t, TestEnv, rolloutTestNS, rolloutCRName, rolloutTestTimeout)
+	requireNoErrorWithDebugging(t, TestEnv, err,
+		"Initial pod should be running and ready", rolloutTestNS, rolloutCRName)
+}
+
+func testDeploymentStrategy(t *testing.T) {
+	t.Helper()
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
+		Namespace: rolloutTestNS, Name: rolloutCRName,
+	}, deployment))
+
+	assert.Equal(t, appsv1.RecreateDeploymentStrategyType,
+		deployment.Spec.Strategy.Type,
+		"Deployment with persistent storage should use Recreate strategy "+
+			"to avoid RWO PVC multi-attach deadlock")
+}
+
+func testRolloutAfterEnvVarUpdate(t *testing.T) {
+	t.Helper()
+
+	initialPods, err := GetPodsForDeployment(TestEnv, TestEnv.Ctx, rolloutTestNS, rolloutCRName)
+	require.NoError(t, err)
+	require.Len(t, initialPods.Items, 1, "Should have exactly 1 pod before rollout")
+	initialPodName := initialPods.Items[0].Name
+	initialNodeName := initialPods.Items[0].Spec.NodeName
+	t.Logf("Initial pod: %s on node: %s", initialPodName, initialNodeName)
+
+	cordonNodeForTest(t, initialNodeName)
+
+	t.Log("Updating OLLAMA_INFERENCE_MODEL to trigger rollout")
+	updateDistributionEnvVar(t, rolloutTestNS, rolloutCRName, ollamaInferenceModelEnv, "llama3.2:3b")
+
+	// Poll until the operator reconciles the env var into the Deployment,
+	// otherwise the old (still-ready) Deployment passes readiness immediately.
+	t.Log("Waiting for operator to update Deployment with new env var")
+	waitForDeploymentEnvVar(t, rolloutTestNS, rolloutCRName, ollamaInferenceModelEnv, "llama3.2:3b")
+
+	t.Log("Waiting for rollout to complete")
+	err = EnsureResourceReady(t, TestEnv, schema.GroupVersionKind{
+		Group: "apps", Version: "v1", Kind: "Deployment",
+	}, rolloutCRName, rolloutTestNS, rolloutTestTimeout, isDeploymentReady)
+	requireNoErrorWithDebugging(t, TestEnv, err,
+		"Deployment rollout should complete after env var update", rolloutTestNS, rolloutCRName)
+
+	err = WaitForPodsReady(t, TestEnv, rolloutTestNS, rolloutCRName, rolloutTestTimeout)
+	requireNoErrorWithDebugging(t, TestEnv, err,
+		"New pod should be running and ready after rollout", rolloutTestNS, rolloutCRName)
+
+	rolledPods, err := GetPodsForDeployment(TestEnv, TestEnv.Ctx, rolloutTestNS, rolloutCRName)
+	require.NoError(t, err)
+	require.Len(t, rolledPods.Items, 1, "Should have exactly 1 pod after rollout")
+
+	newPodName := rolledPods.Items[0].Name
+	t.Logf("New pod: %s", newPodName)
+	assert.NotEqual(t, initialPodName, newPodName,
+		"Pod name should change after rollout, confirming a new pod was created")
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
+		Namespace: rolloutTestNS, Name: rolloutCRName,
+	}, deployment))
+
+	found := false
+	for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == ollamaInferenceModelEnv {
+			assert.Equal(t, "llama3.2:3b", env.Value)
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "OLLAMA_INFERENCE_MODEL env var should be present in deployment")
+}
+
+func testNoFailedAttachVolumeEvents(t *testing.T) {
+	t.Helper()
+
+	eventList := &corev1.EventList{}
+	require.NoError(t, TestEnv.Client.List(TestEnv.Ctx, eventList, client.InNamespace(rolloutTestNS)))
+
+	for _, event := range eventList.Items {
+		if event.Reason == "FailedAttachVolume" {
+			// Transient during cross-node volume migration with Recreate strategy.
+			// A permanent deadlock (RollingUpdate) would have timed out above.
+			t.Logf("Transient FailedAttachVolume (expected): %s", event.Message)
+		}
+	}
+}
+
+func testRolloutCleanup(t *testing.T) {
+	t.Helper()
+
+	distribution := &v1alpha1.LlamaStackDistribution{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rolloutCRName,
+			Namespace: rolloutTestNS,
+		},
+	}
+	err := TestEnv.Client.Delete(TestEnv.Ctx, distribution)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		require.NoError(t, err)
+	}
+
+	err = EnsureResourceDeleted(t, TestEnv, schema.GroupVersionKind{
+		Group: "apps", Version: "v1", Kind: "Deployment",
+	}, rolloutCRName, rolloutTestNS, ResourceReadyTimeout)
+	require.NoError(t, err, "Deployment should be deleted")
+}
+
+// cordonNodeForTest marks a node as unschedulable and registers a
+// t.Cleanup to uncordon it when the test finishes.
+func cordonNodeForTest(t *testing.T, nodeName string) {
+	t.Helper()
+
+	t.Logf("Cordoning node %s to force cross-node scheduling", nodeName)
+	node := &corev1.Node{}
+	require.NoError(t, TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
+		Name: nodeName,
+	}, node))
+	node.Spec.Unschedulable = true
+	require.NoError(t, TestEnv.Client.Update(TestEnv.Ctx, node))
+
+	t.Cleanup(func() {
+		t.Logf("Uncordoning node %s", nodeName)
+		uncordonNode := &corev1.Node{}
+		if getErr := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
+			Name: nodeName,
+		}, uncordonNode); getErr == nil {
+			uncordonNode.Spec.Unschedulable = false
+			if updateErr := TestEnv.Client.Update(TestEnv.Ctx, uncordonNode); updateErr != nil {
+				t.Logf("WARNING: Failed to uncordon node %s: %v", nodeName, updateErr)
+			}
+		}
+	})
+}
+
+// updateDistributionEnvVar updates an env var on a LlamaStackDistribution,
+// retrying on conflict.
+func updateDistributionEnvVar(t *testing.T, namespace, name, envName, newValue string) {
+	t.Helper()
+
+	err := wait.PollUntilContextTimeout(TestEnv.Ctx, time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		latest := &v1alpha1.LlamaStackDistribution{}
+		if getErr := TestEnv.Client.Get(ctx, client.ObjectKey{
+			Namespace: namespace, Name: name,
+		}, latest); getErr != nil {
+			return false, getErr
+		}
+
+		for i, env := range latest.Spec.Server.ContainerSpec.Env {
+			if env.Name == envName {
+				latest.Spec.Server.ContainerSpec.Env[i].Value = newValue
+				break
+			}
+		}
+
+		if updateErr := TestEnv.Client.Update(ctx, latest); updateErr != nil {
+			if k8serrors.IsConflict(updateErr) {
+				return false, nil
+			}
+			return false, updateErr
+		}
+		return true, nil
+	})
+	require.NoError(t, err, "Failed to update CR env var "+envName)
+}
+
+// waitForDeploymentEnvVar polls until the Deployment's container spec
+// reflects the expected env var value.
+func waitForDeploymentEnvVar(t *testing.T, namespace, name, envName, expectedValue string) {
+	t.Helper()
+
+	err := wait.PollUntilContextTimeout(TestEnv.Ctx, pollInterval, rolloutTestTimeout, true, func(ctx context.Context) (bool, error) {
+		dep := &appsv1.Deployment{}
+		if getErr := TestEnv.Client.Get(ctx, client.ObjectKey{
+			Namespace: namespace, Name: name,
+		}, dep); getErr != nil {
+			return false, getErr
+		}
+		for _, env := range dep.Spec.Template.Spec.Containers[0].Env {
+			if env.Name == envName && env.Value == expectedValue {
+				t.Log("Deployment updated with new env var")
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	requireNoErrorWithDebugging(t, TestEnv, err,
+		"Operator should propagate env var change to Deployment", namespace, name)
+}


### PR DESCRIPTION
## Description

Cherry-pick all commits from upstream v0.8.0..v0.9.0 to the midstream odh branch for RHOAI 3.4.

**Changes:**
- 9 upstream commits cherry-picked (fixes, docs, dependency bumps)
- Version bump to v0.9.0 (distributions.json, operator version, release manifests)
- component_metadata.yaml updated: Llama Stack v0.7.1, Operator v0.9.0

**Key fixes included:**
- fix(deploy): set Recreate strategy when persistent storage is configured
- fix(ca-bundle): handle whitespace-only keys as valid empty state
- fix(operator): use maxUnavailable for single-replica PDBs
- fix(deploy): remove stale user-config volume when userConfig is cleared
- fix: memory improvements for ConfigMap tracking
- fix: Bump go version to 1.25.8
- docs: document ENABLE_INLINE_MILVUS limitations in README

**Upstream release:**
- Tag: [v0.9.0](https://github.com/llamastack/llama-stack-k8s-operator/releases/tag/v0.9.0)
- Workflow: [Generate Release](https://github.com/llamastack/llama-stack-k8s-operator/actions/runs/24242533960)

**Conflict resolution:**
- `.github/workflows/build-image.yml`: removed (does not exist in midstream, Konflux is used instead)
- `controllers/llamastackdistribution_controller.go`: kept both midstream needsConfigMapUpdate logic and upstream watch label logic
- `release/operator.yaml` + `config/manager/manager.yaml`: kept midstream RELATED_IMAGE_RH_DISTRIBUTION env var, took upstream version numbers

## How Has This Been Tested?

- Upstream v0.9.0 release workflow passed all E2E tests: [run 24242533960](https://github.com/llamastack/llama-stack-k8s-operator/actions/runs/24242533960)
- Cherry-pick conflicts resolved manually and verified for correctness
- component_metadata.yaml versions confirmed against upstream release and current distribution version

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for local vector storage (inline::milvus) with environment configuration option.
  * Enhanced operator configuration refresh to detect feature flag changes dynamically.

* **Bug Fixes**
  * Fixed deployment strategy handling for storage-configured distributions.
  * Improved handling of empty/whitespace-only certificate data.

* **Documentation**
  * Added inline::milvus local vector storage setup instructions with single-worker deployment constraints.

* **Chores**
  * Updated operator to v0.9.0 and distributions to v0.7.1.
  * Updated Go toolchain and GitHub Actions dependencies.
  * Revised PodDisruptionBudget policy semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->