### PR TITLE
Support rh-dev as deprecated alias for rh distribution

### DIFF
--- a/api/v1beta1/ogxserver_webhook.go
+++ b/api/v1beta1/ogxserver_webhook.go
@@ -80,12 +80,23 @@ func (v *OGXServerValidator) ValidateDelete(_ context.Context, _ runtime.Object)
 	return nil, nil
 }
 
+// DeprecatedDistributions maps deprecated distribution names to their replacements.
+var DeprecatedDistributions = map[string]string{
+	"rh-dev": "rh",
+}
+
 func (v *OGXServerValidator) validate(r *OGXServer) (admission.Warnings, error) {
 	allErrs := v.collectValidationErrors(r)
 	if len(allErrs) > 0 {
 		return nil, allErrs.ToAggregate()
 	}
-	return nil, nil
+
+	var warnings admission.Warnings
+	if replacement, ok := DeprecatedDistributions[r.Spec.Distribution.Name]; ok {
+		warnings = append(warnings,
+			fmt.Sprintf("spec.distribution.name %q is deprecated, use %q instead", r.Spec.Distribution.Name, replacement))
+	}
+	return warnings, nil
 }
 
 func (v *OGXServerValidator) collectValidationErrors(r *OGXServer) field.ErrorList {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -29,7 +29,8 @@ func NewClusterInfo(ctx context.Context, client client.Client, embeddedDistribut
 	var distributionImages map[string]string
 	if os.Getenv("RELATED_IMAGE_RH_DISTRIBUTION") != "" {
 		distributionImages = map[string]string{
-			"rh": os.Getenv("RELATED_IMAGE_RH_DISTRIBUTION"),
+			"rh":     os.Getenv("RELATED_IMAGE_RH_DISTRIBUTION"),
+			"rh-dev": os.Getenv("RELATED_IMAGE_RH_DISTRIBUTION"),
 		}
 	} else {
 		if err := json.Unmarshal(embeddedDistributions, &distributionImages); err != nil {


### PR DESCRIPTION
## Summary
- Adds `rh-dev` as an alias for the `rh` distribution in `cluster.go`, both pointing to the same `RELATED_IMAGE_RH_DISTRIBUTION` image
- Returns an admission warning when `rh-dev` is used, advising users to switch to `rh`

This unblocks existing deployments (e.g. Gen AI Studio E2E tests) that still reference `rh-dev` after the rename in #129, without reverting the rename.

Context: https://redhat-internal.slack.com/archives/C08P7FYQ94J/p1781876701913219?thread_ts=1781871905.904409&cid=C08P7FYQ94J

## Test plan
- [ ] Deploy operator, create OGXServer CR with `distribution.name: rh-dev` - should succeed with deprecation warning
- [ ] Create OGXServer CR with `distribution.name: rh` - should succeed with no warning
- [ ] Verify existing webhook validation still rejects unknown distribution names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deprecation warnings for older distribution names, guiding users to updated naming conventions.

* **Bug Fixes**
  * Enhanced compatibility to recognize and support both current and legacy distribution name formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->