### PR TITLE
fix: Update rbac for ogx-module

### DIFF
--- a/.tekton/odh-ogx-module-operator-pull-request.yaml
+++ b/.tekton/odh-ogx-module-operator-pull-request.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-ogx-module-operator:odh-pr
   - name: dockerfile
-    value: Dockerfile
+    value: ogx-module/Dockerfile
   - name: path-context
     value: .
   #add these additional params

--- a/.tekton/odh-ogx-module-operator-push.yaml
+++ b/.tekton/odh-ogx-module-operator-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-ogx-module-operator:odh-stable
   - name: dockerfile
-    value: Dockerfile
+    value: ogx-module/Dockerfile
   - name: path-context
     value: .
   pipelineRef:

--- a/.tekton/odh-ogx-module-operator-release-push.yaml
+++ b/.tekton/odh-ogx-module-operator-release-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-ogx-module-operator:3.5.0
   - name: dockerfile
-    value: Dockerfile
+    value: ogx-module/Dockerfile
   - name: path-context
     value: .
   pipelineRef:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ ENVTEST_K8S_VERSION = 1.31.0
 # Image URL to use all building/pushing image targets
 IMG_TAG ?= latest
 IMG ?= $(IMAGE_TAG_BASE):$(IMG_TAG)
-OGX_MODULE_IMG ?= quay.io/opendatahub/odh-ogx-module-operator:latest
+OGX_MODULE_IMG ?= quay.io/opendatahub/odh-ogx-module-operator:odh-stable
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -321,12 +321,12 @@ deploy-openshift: manifests kustomize ## Deploy controller to an OpenShift clust
 
 .PHONY: ogx-module-deploy
 ogx-module-deploy: kustomize ## Deploy the ogx-module operator from its default bundle.
-	cd ogx-module/config/manager && $(KUSTOMIZE) edit set image controller=${OGX_MODULE_IMG}
-	$(KUSTOMIZE) build ogx-module/config/default | kubectl apply -f -
+	@echo "RELATED_IMAGE_ODH_OGX_MODULE_OPERATOR_IMAGE=${OGX_MODULE_IMG}" > ogx-module/config/overlays/odh/params.env
+	$(KUSTOMIZE) build ogx-module/config/overlays/odh | kubectl apply -f -
 
 .PHONY: ogx-module-undeploy
 ogx-module-undeploy: kustomize ## Undeploy the ogx-module operator from the current cluster.
-	$(KUSTOMIZE) build ogx-module/config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build ogx-module/config/overlays/odh | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/ogx-module/config/manager/kustomization.yaml
+++ b/ogx-module/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
 images:
 - name: controller
   newName: quay.io/opendatahub/odh-ogx-module-operator
-  newTag: latest
+  newTag: odh-stable

--- a/ogx-module/config/rbac/cluster_role.yaml
+++ b/ogx-module/config/rbac/cluster_role.yaml
@@ -29,6 +29,14 @@ rules:
     verbs:
       - list
   - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apps
     resources:
       - deployments
@@ -39,6 +47,14 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
       - watch
   - apiGroups:
       - autoscaling
@@ -178,6 +194,27 @@ rules:
     resources:
       - clusterrolebindings
       - clusterroles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - apiservers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+      - servicemonitors
     verbs:
       - create
       - delete


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The ogx-module controller fails to deploy the root OGX operator when the OGX CR is created. The module controller's ClusterRole (opendatahub-ogx-manager-cluster-role) is missing permissions that were added to the root operator's ClusterRole (ogx-k8s-operator-manager-role) in recent features.

 Since the ogx-module deploys the root operator's ClusterRole, it must hold at least the same set of permissions.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Deployment**
  * Updated automated builds and releases to use the correct module container configuration.
  * Deployments now use the stable container image stream and the OpenDataHub-specific configuration.
* **Permissions**
  * Adjusted operator access to support required secrets, replica sets, API server settings, and monitoring resources.
  * Added monitoring integration permissions for Prometheus rules and service monitors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->