### PR TITLE
refactor: add necessary  image placeholders for disconnected (#312)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,6 +58,14 @@ spec:
           value: "latest"
         - name: RELATED_IMAGE_ODH_OGX_CORE_IMAGE
           value: ""
+        - name: RELATED_IMAGE_STARTER
+          value: ""
+        - name: RELATED_IMAGE_REMOTE_VLLM
+          value: ""
+        - name: RELATED_IMAGE_META_REFERENCE_GPU
+          value: ""
+        - name: RELATED_IMAGE_POSTGRES_DEMO
+          value: ""
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/ogx-ai/ogx-k8s-operator/pkg/deploy"
@@ -38,10 +39,29 @@ func NewClusterInfo(ctx context.Context, client client.Client, embeddedDistribut
 		}
 	}
 
+	applyRelatedImageOverrides(distributionImages)
+
 	return &ClusterInfo{
 		OperatorNamespace:  operatorNamespace,
 		DistributionImages: distributionImages,
 	}, nil
+}
+
+// applyRelatedImageOverrides overrides distribution images with RELATED_IMAGE_* env vars
+// when set. OLM injects these with mirrored image digests for disconnected environments.
+func applyRelatedImageOverrides(distributionImages map[string]string) {
+	for name := range distributionImages {
+		envKey := DistributionEnvVarKey(name)
+		if override := os.Getenv(envKey); override != "" {
+			distributionImages[name] = override
+		}
+	}
+}
+
+// DistributionEnvVarKey converts a distribution name to its RELATED_IMAGE_* env var name.
+// Example: "remote-vllm" becomes "RELATED_IMAGE_REMOTE_VLLM".
+func DistributionEnvVarKey(name string) string {
+	return "RELATED_IMAGE_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
 }
 
 // PerformUpgradeCleanup performs one-time cleanup operations for seamless upgrades.

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestDistributionsJSONIsValid ensures that the distributions.json file always
@@ -27,4 +29,79 @@ func TestDistributionsJSONIsValid(t *testing.T) {
 			t.Fatalf("failed to validate distributions.json: contains an empty value for key %q", k)
 		}
 	}
+}
+
+func TestDistributionEnvVarKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{name: "starter", expected: "RELATED_IMAGE_STARTER"},
+		{name: "remote-vllm", expected: "RELATED_IMAGE_REMOTE_VLLM"},
+		{name: "meta-reference-gpu", expected: "RELATED_IMAGE_META_REFERENCE_GPU"},
+		{name: "postgres-demo", expected: "RELATED_IMAGE_POSTGRES_DEMO"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, DistributionEnvVarKey(tt.name))
+		})
+	}
+}
+
+func TestNewClusterInfoRelatedImageOverrides(t *testing.T) {
+	distributions := `{
+		"starter": "docker.io/ogxai/distribution-starter:latest",
+		"remote-vllm": "docker.io/ogxai/distribution-remote-vllm:latest",
+		"meta-reference-gpu": "docker.io/ogxai/distribution-meta-reference-gpu:latest"
+	}`
+
+	t.Run("no env vars set uses distributions.json defaults", func(t *testing.T) {
+		var images map[string]string
+		require.NoError(t, json.Unmarshal([]byte(distributions), &images))
+
+		applyRelatedImageOverrides(images)
+
+		require.Equal(t, "docker.io/ogxai/distribution-starter:latest", images["starter"])
+		require.Equal(t, "docker.io/ogxai/distribution-remote-vllm:latest", images["remote-vllm"])
+		require.Equal(t, "docker.io/ogxai/distribution-meta-reference-gpu:latest", images["meta-reference-gpu"])
+	})
+
+	t.Run("env var overrides single distribution", func(t *testing.T) {
+		t.Setenv("RELATED_IMAGE_STARTER", "mirror.example.com/ogx-starter@sha256:abc123")
+
+		var images map[string]string
+		require.NoError(t, json.Unmarshal([]byte(distributions), &images))
+
+		applyRelatedImageOverrides(images)
+
+		require.Equal(t, "mirror.example.com/ogx-starter@sha256:abc123", images["starter"])
+		require.Equal(t, "docker.io/ogxai/distribution-remote-vllm:latest", images["remote-vllm"])
+	})
+
+	t.Run("env var overrides all distributions", func(t *testing.T) {
+		t.Setenv("RELATED_IMAGE_STARTER", "mirror.example.com/starter@sha256:aaa")
+		t.Setenv("RELATED_IMAGE_REMOTE_VLLM", "mirror.example.com/vllm@sha256:bbb")
+		t.Setenv("RELATED_IMAGE_META_REFERENCE_GPU", "mirror.example.com/gpu@sha256:ccc")
+
+		var images map[string]string
+		require.NoError(t, json.Unmarshal([]byte(distributions), &images))
+
+		applyRelatedImageOverrides(images)
+
+		require.Equal(t, "mirror.example.com/starter@sha256:aaa", images["starter"])
+		require.Equal(t, "mirror.example.com/vllm@sha256:bbb", images["remote-vllm"])
+		require.Equal(t, "mirror.example.com/gpu@sha256:ccc", images["meta-reference-gpu"])
+	})
+
+	t.Run("empty env var does not override", func(t *testing.T) {
+		t.Setenv("RELATED_IMAGE_STARTER", "")
+
+		var images map[string]string
+		require.NoError(t, json.Unmarshal([]byte(distributions), &images))
+
+		applyRelatedImageOverrides(images)
+
+		require.Equal(t, "docker.io/ogxai/distribution-starter:latest", images["starter"])
+	})
 }

--- a/release/operator-openshift.yaml
+++ b/release/operator-openshift.yaml
@@ -7305,6 +7305,14 @@ spec:
           value: latest
         - name: RELATED_IMAGE_ODH_OGX_CORE_IMAGE
           value: ""
+        - name: RELATED_IMAGE_STARTER
+          value: ""
+        - name: RELATED_IMAGE_REMOTE_VLLM
+          value: ""
+        - name: RELATED_IMAGE_META_REFERENCE_GPU
+          value: ""
+        - name: RELATED_IMAGE_POSTGRES_DEMO
+          value: ""
         image: quay.io/ogx-ai/ogx-k8s-operator:latest
         imagePullPolicy: Always
         livenessProbe:

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -7304,6 +7304,14 @@ spec:
           value: latest
         - name: RELATED_IMAGE_ODH_OGX_CORE_IMAGE
           value: ""
+        - name: RELATED_IMAGE_STARTER
+          value: ""
+        - name: RELATED_IMAGE_REMOTE_VLLM
+          value: ""
+        - name: RELATED_IMAGE_META_REFERENCE_GPU
+          value: ""
+        - name: RELATED_IMAGE_POSTGRES_DEMO
+          value: ""
         image: quay.io/ogx-ai/ogx-k8s-operator:latest
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
Addressing the disconnected scanner results from
https://github.com/opendatahub-io/disconnected-readiness-scorer/actions/runs/27770487578. The remediation documentation for that is located at https://github.com/opendatahub-io/disconnected-readiness-scorer/blob/main/docs/remediation-guide.md.

Adds generic `RELATED_IMAGE_*` environment variable override support so OLM can inject mirrored image digests in disconnected/air-gapped OpenShift clusters.

This addresses disconnected readiness scanner findings (`image-manifest-complete` and `params-env-wiring` blockers) by following the standard OLM `RELATED_IMAGE` pattern. When no env vars are set, behavior is unchanged.

Closes `RHOAIENG-70001`




(cherry picked from commit fab1a4b2db2ae6ca4d4594e453f5fe7879b88b53)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for overriding component container images through environment variables.
  * Added configurable image references for Starter, Remote vLLM, Meta Reference GPU, and Postgres Demo components.
  * Applied image override settings across supported deployment configurations.

* **Tests**
  * Added coverage for image override behavior and environment variable naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->