### PR TITLE
ci: bump disconnected-readiness-scorer to include OGX exemptions

### DIFF
--- a/.github/workflows/disconnected-readiness.yml
+++ b/.github/workflows/disconnected-readiness.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   check:
-    uses: opendatahub-io/disconnected-readiness-scorer/.github/workflows/disconnected-readiness-check.yml@6f7fc06230f5eeabfd134d819219314d54f0c7e7  # v1.0.0
+    uses: opendatahub-io/disconnected-readiness-scorer/.github/workflows/disconnected-readiness-check.yml@226afbf23967c44422b97654d054e01014038905  # scorer main (post-v1.3.0) — incl. OGX exemptions drs#82/#85; repin to release tag when cut
     with:
       rules: ""


### PR DESCRIPTION
## What

Bump the `disconnected-readiness-scorer` reusable workflow pin from `6f7fc06` to scorer `main` (`226afbf`).

## Why

The currently pinned scorer commit (`6f7fc06`, 2026-07-07) predates the OGX exemptions merged in the scorer repo:

- opendatahub-io/disconnected-readiness-scorer#82
- opendatahub-io/disconnected-readiness-scorer#85

Because the pin is older than those merges, the exemptions never take effect, and the **Disconnected Readiness** check reports 11 false-positive blockers on every OGX operator PR (`image-manifest-complete`, `no-image-tags`, `params-env-wiring`).

Bumping to `226afbf` (scorer `main`, which carries #82 + #85) clears those false positives.

## Note

This is an **interim SHA pin** — the raw commit was used because no release tag past `v1.3.0` yet carries these exemptions. Once a new release tag is cut off `main`, this should be repointed to that tag to restore the `# vX.Y.Z` convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the disconnected-readiness validation workflow to use the latest scorer revision.
  * Clarified the workflow comment regarding scorer updates and OGX exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->