### PR TITLE
Add platform entry in module status

### DIFF
--- a/ogx-module/internal/controller/ogx/reconciler.go
+++ b/ogx-module/internal/controller/ogx/reconciler.go
@@ -31,12 +31,17 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
@@ -50,6 +55,14 @@ const (
 	conditionTypeRootWebhookReady  = "RootWebhookReady"
 	ogxServerDeploymentReady       = "DeploymentReady"
 	ogxServerHealthCheck           = "HealthCheck"
+
+	// platformConfigCMName is the ODH-managed ConfigMap (odh-<module>-config)
+	// that carries data.platformVersion for the version handshake.
+	platformConfigCMName = "odh-" + componentName + "-config"
+	// platformVersionDataKey is the camelCase key injected by the platform
+	// operator. The kebab-case config key is accepted as a fallback.
+	platformVersionDataKey = "platformVersion"
+	platformReleaseName    = "platform"
 )
 
 var (
@@ -134,6 +147,15 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&rbacv1.ClusterRoleBinding{}).
 		Owns(&admissionv1.ValidatingWebhookConfiguration{}).
 		Owns(&extv1.CustomResourceDefinition{}).
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, _ client.Object) []reconcile.Request {
+				return []reconcile.Request{{
+					NamespacedName: types.NamespacedName{Name: platformv1alpha1.OGXInstanceName},
+				}}
+			}),
+			builder.WithPredicates(predicate.NewPredicateFuncs(r.isPlatformConfigMap)),
+		).
 		Complete(r)
 }
 
@@ -154,12 +176,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
+	if err := r.refreshPlatformVersion(ctx); err != nil {
+		r.updateStatusOnError(ctx, instance, false, false, false, err, "failed to update status after platform config error")
+		return ctrl.Result{}, err
+	}
+
 	rendered, err := r.renderRootOperatorResources()
 	if err != nil {
-		statusErr := r.updateStatus(ctx, instance, false, false, false, ogxServerHealthSummary{}, err)
-		if statusErr != nil {
-			logger.Error(statusErr, "failed to update status after render error")
-		}
+		r.updateStatusOnError(ctx, instance, false, false, false, err, "failed to update status after render error")
 		return ctrl.Result{}, err
 	}
 
@@ -189,37 +213,25 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		Resources: rendered,
 	})
 	if err != nil {
-		statusErr := r.updateStatus(ctx, instance, false, false, false, ogxServerHealthSummary{}, err)
-		if statusErr != nil {
-			logger.Error(statusErr, "failed to update status after deploy error")
-		}
+		r.updateStatusOnError(ctx, instance, false, false, false, err, "failed to update status after deploy error")
 		return ctrl.Result{}, err
 	}
 
 	deploymentsReady, readyErr := r.rootDeploymentsReady(ctx, rendered)
 	if readyErr != nil {
-		statusErr := r.updateStatus(ctx, instance, true, false, false, ogxServerHealthSummary{}, readyErr)
-		if statusErr != nil {
-			logger.Error(statusErr, "failed to update status after readiness error")
-		}
+		r.updateStatusOnError(ctx, instance, true, false, false, readyErr, "failed to update status after readiness error")
 		return ctrl.Result{}, readyErr
 	}
 
 	webhookReady, webhookErr := r.rootWebhookResourcesReady(ctx, rendered)
 	if webhookErr != nil {
-		statusErr := r.updateStatus(ctx, instance, true, deploymentsReady, false, ogxServerHealthSummary{}, webhookErr)
-		if statusErr != nil {
-			logger.Error(statusErr, "failed to update status after webhook readiness error")
-		}
+		r.updateStatusOnError(ctx, instance, true, deploymentsReady, false, webhookErr, "failed to update status after webhook readiness error")
 		return ctrl.Result{}, webhookErr
 	}
 
 	healthSummary, healthErr := r.aggregateOGXServerHealth(ctx)
 	if healthErr != nil {
-		statusErr := r.updateStatus(ctx, instance, true, deploymentsReady, webhookReady, ogxServerHealthSummary{}, healthErr)
-		if statusErr != nil {
-			logger.Error(statusErr, "failed to update status after OGXServer health error")
-		}
+		r.updateStatusOnError(ctx, instance, true, deploymentsReady, webhookReady, healthErr, "failed to update status after OGXServer health error")
 		return ctrl.Result{}, healthErr
 	}
 
@@ -502,7 +514,7 @@ func (r *Reconciler) updateStatus(
 	instance.Status.ObservedGeneration = instance.Generation
 	instance.Status.Distribution = platformv1alpha1.OGXDistribution{
 		Name:    r.Config.PlatformName,
-		Version: r.Config.PlatformVersion,
+		Version: r.platformVersion(),
 	}
 
 	releases, err := r.loadComponentReleases()
@@ -512,15 +524,7 @@ func (r *Reconciler) updateStatus(
 		instance.Status.ComponentReleaseStatus = releases
 	}
 
-	if r.Config.PlatformVersion != "" && r.Config.PlatformVersion != "unknown" {
-		instance.Status.ComponentReleaseStatus.Releases = append(
-			instance.Status.ComponentReleaseStatus.Releases,
-			common.ComponentRelease{
-				Name:    "platform",
-				Version: r.Config.PlatformVersion,
-			},
-		)
-	}
+	setPlatformRelease(&instance.Status.ComponentReleaseStatus, r.platformVersion())
 
 	cm := odhconditions.NewManager(
 		instance,
@@ -678,6 +682,20 @@ func (r *Reconciler) updateStatus(
 	return r.Status().Update(ctx, instance)
 }
 
+func (r *Reconciler) updateStatusOnError(
+	ctx context.Context,
+	instance *platformv1alpha1.OGX,
+	provisioningSucceeded bool,
+	rootOperatorReady bool,
+	rootWebhookReady bool,
+	reconcileErr error,
+	statusLogMsg string,
+) {
+	if statusErr := r.updateStatus(ctx, instance, provisioningSucceeded, rootOperatorReady, rootWebhookReady, ogxServerHealthSummary{}, reconcileErr); statusErr != nil {
+		log.FromContext(ctx).Error(statusErr, statusLogMsg)
+	}
+}
+
 func (r *Reconciler) loadComponentReleases() (common.ComponentReleaseStatus, error) {
 	path := filepath.Join(r.Config.ManifestsPath, componentName, "component_metadata.yaml")
 	data, err := os.ReadFile(path)
@@ -707,6 +725,81 @@ func ensureFinalizer(instance *platformv1alpha1.OGX) bool {
 
 func clearFinalizer(instance *platformv1alpha1.OGX) bool {
 	return controllerutil.RemoveFinalizer(instance, ogxFinalizer)
+}
+
+func (r *Reconciler) refreshPlatformVersion(ctx context.Context) error {
+	version, err := r.readPlatformVersionFromConfigMap(ctx)
+	if err != nil {
+		return err
+	}
+	if version != "" && r.Config != nil {
+		r.Config.PlatformVersion = version
+	}
+
+	return nil
+}
+
+func (r *Reconciler) readPlatformVersionFromConfigMap(ctx context.Context) (string, error) {
+	if r.Config == nil || r.Config.ApplicationsNamespace == "" {
+		return "", nil
+	}
+
+	cm := &corev1.ConfigMap{}
+	err := r.Get(ctx, client.ObjectKey{
+		Name:      platformConfigCMName,
+		Namespace: r.Config.ApplicationsNamespace,
+	}, cm)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("failed to get platform config ConfigMap %s/%s: %w", r.Config.ApplicationsNamespace, platformConfigCMName, err)
+	}
+
+	if cm.Data == nil {
+		return "", nil
+	}
+
+	if version := strings.TrimSpace(cm.Data[platformVersionDataKey]); version != "" {
+		return version, nil
+	}
+
+	return strings.TrimSpace(cm.Data[moduleconfig.KeyPlatformVersion]), nil
+}
+
+func (r *Reconciler) platformVersion() string {
+	if r.Config == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(r.Config.PlatformVersion)
+}
+
+func (r *Reconciler) isPlatformConfigMap(obj client.Object) bool {
+	if r.Config == nil {
+		return false
+	}
+
+	return obj.GetName() == platformConfigCMName && obj.GetNamespace() == r.Config.ApplicationsNamespace
+}
+
+func setPlatformRelease(status *common.ComponentReleaseStatus, version string) {
+	if status == nil || version == "" || version == moduleconfig.DefaultPlatformVersion {
+		return
+	}
+
+	for i := range status.Releases {
+		if status.Releases[i].Name == platformReleaseName {
+			status.Releases[i].Version = version
+			return
+		}
+	}
+
+	status.Releases = append(status.Releases, common.ComponentRelease{
+		Name:    platformReleaseName,
+		Version: version,
+	})
 }
 
 func overlayForPlatform(platformName string) string {

--- a/ogx-module/internal/controller/ogx/reconciler_test.go
+++ b/ogx-module/internal/controller/ogx/reconciler_test.go
@@ -360,6 +360,152 @@ func TestReconcileRemovedClearsFinalizerAndRunsGC(t *testing.T) {
 	}
 }
 
+func TestReconcileReportsPlatformReleaseFromConfigMap(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(clientgoscheme): %v", err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(platformv1alpha1): %v", err)
+	}
+
+	const applicationsNS = "opendatahub"
+	manifestsRoot := writeMinimalManifestTree(t)
+	instance := &platformv1alpha1.OGX{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: platformv1alpha1.GroupVersion.String(),
+			Kind:       platformv1alpha1.OGXKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       platformv1alpha1.OGXInstanceName,
+			Generation: 1,
+		},
+		Spec: platformv1alpha1.OGXSpec{
+			ManagementSpec: common.ManagementSpec{ManagementState: common.Managed},
+		},
+	}
+	platformCM := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      platformConfigCMName,
+			Namespace: applicationsNS,
+		},
+		Data: map[string]string{
+			"platform-name":        "OpenDataHub",
+			platformVersionDataKey: "0.0.0",
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&platformv1alpha1.OGX{}).
+		WithObjects(instance, platformCM).
+		Build()
+
+	reconciler := NewReconciler(cli, cli, scheme, &moduleconfig.Config{
+		ManifestsPath:         manifestsRoot,
+		ApplicationsNamespace: applicationsNS,
+		PlatformName:          "OpenDataHub",
+		PlatformVersion:       moduleconfig.DefaultPlatformVersion,
+	}, nil, nil)
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(instance)}); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	updated := &platformv1alpha1.OGX{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(instance), updated); err != nil {
+		t.Fatalf("Get(updated OGX): %v", err)
+	}
+
+	assertPlatformHandshake(t, updated, "0.0.0")
+}
+
+func TestIsPlatformConfigMap(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &Reconciler{
+		Config: &moduleconfig.Config{ApplicationsNamespace: "opendatahub"},
+	}
+
+	tests := []struct {
+		name      string
+		objName   string
+		namespace string
+		want      bool
+	}{
+		{name: "platform configmap", objName: platformConfigCMName, namespace: "opendatahub", want: true},
+		{name: "wrong name", objName: "other-config", namespace: "opendatahub", want: false},
+		{name: "wrong namespace", objName: platformConfigCMName, namespace: "other", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: tt.objName, Namespace: tt.namespace}}
+			if got := reconciler.isPlatformConfigMap(obj); got != tt.want {
+				t.Fatalf("isPlatformConfigMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetPlatformRelease(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		existing []common.ComponentRelease
+		version  string
+		want     []common.ComponentRelease
+	}{
+		{
+			name:    "appends platform entry",
+			version: "0.0.0",
+			want:    []common.ComponentRelease{{Name: platformReleaseName, Version: "0.0.0"}},
+		},
+		{
+			name:     "updates existing platform entry",
+			existing: []common.ComponentRelease{{Name: platformReleaseName, Version: "old"}, {Name: "OGX", Version: "v1.2.1"}},
+			version:  "0.0.0",
+			want:     []common.ComponentRelease{{Name: platformReleaseName, Version: "0.0.0"}, {Name: "OGX", Version: "v1.2.1"}},
+		},
+		{
+			name:     "skips unknown default",
+			existing: []common.ComponentRelease{{Name: "OGX", Version: "v1.2.1"}},
+			version:  moduleconfig.DefaultPlatformVersion,
+			want:     []common.ComponentRelease{{Name: "OGX", Version: "v1.2.1"}},
+		},
+		{
+			name:     "skips empty version",
+			existing: []common.ComponentRelease{{Name: "OGX", Version: "v1.2.1"}},
+			version:  "",
+			want:     []common.ComponentRelease{{Name: "OGX", Version: "v1.2.1"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			status := common.ComponentReleaseStatus{Releases: append([]common.ComponentRelease(nil), tt.existing...)}
+			setPlatformRelease(&status, tt.version)
+			if len(status.Releases) != len(tt.want) {
+				t.Fatalf("len(Releases) = %d, want %d", len(status.Releases), len(tt.want))
+			}
+			for i := range tt.want {
+				if status.Releases[i] != tt.want[i] {
+					t.Fatalf("Releases[%d] = %+v, want %+v", i, status.Releases[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestUpdateStatus(t *testing.T) {
 	t.Parallel()
 
@@ -495,6 +641,7 @@ func TestUpdateStatus(t *testing.T) {
 			if len(updated.Status.Releases) != tt.wantReleaseEntries {
 				t.Fatalf("len(Releases) = %d, want %d", len(updated.Status.Releases), tt.wantReleaseEntries)
 			}
+			assertPlatformHandshake(t, updated, "test-version")
 
 			assertConditionStatus(t, updated, string(common.ConditionTypeReady), tt.wantReady)
 			assertConditionStatus(t, updated, string(common.ConditionTypeProvisioningSucceeded), tt.wantProvisioned)
@@ -502,6 +649,26 @@ func TestUpdateStatus(t *testing.T) {
 			assertConditionStatus(t, updated, conditionTypeRootWebhookReady, tt.wantWebhookReady)
 		})
 	}
+}
+
+func assertPlatformHandshake(t *testing.T, instance *platformv1alpha1.OGX, version string) {
+	t.Helper()
+
+	if got := platformReleaseVersion(instance.Status.Releases); got != version {
+		t.Fatalf("status.releases[name=%q].version = %q, want %q", platformReleaseName, got, version)
+	}
+	if instance.Status.Distribution.Version != version {
+		t.Fatalf("Distribution.Version = %q, want %q", instance.Status.Distribution.Version, version)
+	}
+}
+
+func platformReleaseVersion(releases []common.ComponentRelease) string {
+	for _, release := range releases {
+		if release.Name == platformReleaseName {
+			return release.Version
+		}
+	}
+	return ""
 }
 
 func containsFinalizer(instance *platformv1alpha1.OGX, value string) bool {

--- a/ogx-module/pkg/config/config.go
+++ b/ogx-module/pkg/config/config.go
@@ -95,6 +95,7 @@ func LoadFromFS(fsys fs.FS) (*Config, error) {
 	// alias maps it to the canonical kebab-case key so it populates
 	// Config.PlatformVersion regardless of which key name was used.
 	v.RegisterAlias("platformversion", KeyPlatformVersion)
+	v.RegisterAlias("platformname", KeyPlatformName)
 
 	if fsys != nil {
 		if err := loadFromFS(v, fsys); err != nil {
@@ -175,11 +176,35 @@ func loadFromFS(v *viper.Viper, fsys fs.FS) error {
 		}
 	}
 
-	if err := v.MergeConfigMap(tmp.AllSettings()); err != nil {
+	if err := v.MergeConfigMap(canonicalizeSettings(tmp.AllSettings())); err != nil {
 		return fmt.Errorf("failed to merge config from filesystem: %w", err)
 	}
 
 	return nil
+}
+
+// canonicalizeSettings remaps ODH-injected camelCase ConfigMap keys onto the
+// kebab-case names used by Config. Viper aliases are not applied during
+// Unmarshal, so a projected file named "platformVersion" would otherwise
+// leave PlatformVersion at its default ("unknown").
+func canonicalizeSettings(settings map[string]any) map[string]any {
+	normalized := make(map[string]any, len(settings))
+	for key, value := range settings {
+		normalized[canonicalConfigKey(key)] = value
+	}
+
+	return normalized
+}
+
+func canonicalConfigKey(name string) string {
+	switch strings.ToLower(strings.ReplaceAll(name, "_", "-")) {
+	case "platformversion", KeyPlatformVersion:
+		return KeyPlatformVersion
+	case "platformname", KeyPlatformName:
+		return KeyPlatformName
+	default:
+		return name
+	}
 }
 
 func mergeStructuredFile(v *viper.Viper, name, ext string, data []byte) error {

--- a/ogx-module/pkg/config/config_test.go
+++ b/ogx-module/pkg/config/config_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestLoadFromFSReadsCamelCasePlatformVersion(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := LoadFromFS(fstest.MapFS{
+		"platform-name":   {Data: []byte("OpenDataHub\n")},
+		"platformVersion": {Data: []byte("0.0.0\n")},
+	})
+	if err != nil {
+		t.Fatalf("LoadFromFS() error = %v", err)
+	}
+
+	if cfg.PlatformName != "OpenDataHub" {
+		t.Fatalf("PlatformName = %q, want %q", cfg.PlatformName, "OpenDataHub")
+	}
+	if cfg.PlatformVersion != "0.0.0" {
+		t.Fatalf("PlatformVersion = %q, want %q", cfg.PlatformVersion, "0.0.0")
+	}
+}
+
+func TestLoadFromFSReadsKebabCasePlatformVersion(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := LoadFromFS(fstest.MapFS{
+		"platform-version": {Data: []byte("1.2.3")},
+	})
+	if err != nil {
+		t.Fatalf("LoadFromFS() error = %v", err)
+	}
+
+	if cfg.PlatformVersion != "1.2.3" {
+		t.Fatalf("PlatformVersion = %q, want %q", cfg.PlatformVersion, "1.2.3")
+	}
+}
+
+func TestLoadFromFSDefaultsPlatformVersionWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := LoadFromFS(fstest.MapFS{
+		"platform-name": {Data: []byte("OpenDataHub")},
+	})
+	if err != nil {
+		t.Fatalf("LoadFromFS() error = %v", err)
+	}
+
+	if cfg.PlatformVersion != DefaultPlatformVersion {
+		t.Fatalf("PlatformVersion = %q, want default %q", cfg.PlatformVersion, DefaultPlatformVersion)
+	}
+}
+
+func TestCanonicalConfigKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "platformVersion", want: KeyPlatformVersion},
+		{name: "platformversion", want: KeyPlatformVersion},
+		{name: "platform-version", want: KeyPlatformVersion},
+		{name: "platform_version", want: KeyPlatformVersion},
+		{name: "platformName", want: KeyPlatformName},
+		{name: "manifests-path", want: "manifests-path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := canonicalConfigKey(tt.name); got != tt.want {
+				t.Fatalf("canonicalConfigKey(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What's changed

- During reconcile, the module controller now reads data.platformVersion from odh-ogx-config in the applications namespace.
- It writes {name: platform, version: <platformVersion>} into .status.releases and sets .status.distribution.version.
- It watches that ConfigMap so ConfigMap updates requeue default-ogx.
- Mounted config files also canonicalize platformVersion / platformName onto the kebab-case keys.

After this, an odh-ogx-config with platformVersion: 0.0.0 produces:
```
status:
  distribution:
    version: "0.0.0"
  releases:
    - name: OGX
      version: v1.2.1
    - name: OGX Operator
      version: v0.13.0
    - name: platform
      version: "0.0.0"
```