### PR TITLE
Add e2e tests for module operator 

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -10,6 +10,7 @@ pull_request_rules:
     - label!=needs-rebase
     - check-success=pre-commit
     - check-success=e2e-tests
+    - check-success=ogx-module-e2e-tests
     - check-success=DCO
     - check-success=tests
     # - check-success=build-latest-image # TODO: uncomment this when the credentials are added to the repo

--- a/.github/workflows/run-ogx-module-e2e-test.yml
+++ b/.github/workflows/run-ogx-module-e2e-test.yml
@@ -1,0 +1,144 @@
+name: Run OGX Module E2E Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [ odh ]
+  workflow_call:
+    outputs:
+      success:
+        description: 'Whether the ogx-module e2e tests passed successfully'
+        value: ${{ jobs.ogx-module-e2e-tests.outputs.success }}
+      summary:
+        description: 'High-level summary of test results'
+        value: ${{ jobs.ogx-module-e2e-tests.outputs.summary }}
+      run_url:
+        description: 'URL to this workflow run for detailed logs'
+        value: ${{ jobs.ogx-module-e2e-tests.outputs.run_url }}
+
+jobs:
+  ogx-module-e2e-tests:
+    name: ogx-module-e2e-tests
+    runs-on: ubuntu-latest
+    outputs:
+      success: ${{ steps.test-results.outputs.success }}
+      summary: ${{ steps.test-results.outputs.summary }}
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: ogx-module/go.mod
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Create kind config
+        run: |
+          cat > kind-config.yaml << EOF
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          containerdConfigPatches:
+          - |-
+            [plugins."io.containerd.grpc.v1.cri".registry]
+              config_path = "/etc/containerd/certs.d"
+          nodes:
+          - role: control-plane
+            kubeadmConfigPatches:
+            - |
+              kind: InitConfiguration
+              nodeRegistration:
+                kubeletExtraArgs:
+                  system-reserved: memory=500Mi
+                  eviction-hard: memory.available<200Mi
+          EOF
+
+      - name: Create k8s Kind Cluster
+        id: kind
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          registry: true
+          registry_name: kind-registry
+          registry_port: 5000
+          registry_enable_delete: true
+          config: kind-config.yaml
+
+      - name: Build module operator image
+        run: |
+          docker build -t kind-registry:5000/odh-ogx-module-operator:run-${{ github.run_id }} -f ogx-module/Dockerfile .
+          docker tag kind-registry:5000/odh-ogx-module-operator:run-${{ github.run_id }} kind-registry:5000/odh-ogx-module-operator:latest
+
+      - name: Build root operator image
+        run: |
+          docker build -t kind-registry:5000/ogx-k8s-operator:run-${{ github.run_id }} -f Dockerfile .
+          docker tag kind-registry:5000/ogx-k8s-operator:run-${{ github.run_id }} kind-registry:5000/ogx-k8s-operator:latest
+
+      - name: Push images to local registry
+        run: |
+          echo '{"insecure-registries": ["kind-registry:5000"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          until docker exec kind-registry true 2>/dev/null; do sleep 1; done
+          docker push kind-registry:5000/odh-ogx-module-operator:latest
+          docker push kind-registry:5000/ogx-k8s-operator:latest
+
+      - name: Deploy ogx-module operator
+        run: |
+          make ogx-module-deploy \
+            OGX_MODULE_IMG=kind-registry:5000/odh-ogx-module-operator:latest \
+            OGX_K8S_OPERATOR_IMG=kind-registry:5000/ogx-k8s-operator:latest
+
+          if ! kubectl wait --for=condition=available --timeout=300s deployment/opendatahub-ogx-operator -n opendatahub-ogx-system; then
+            echo "Module operator deployment failed to become ready. Debugging information:"
+            kubectl describe deployment opendatahub-ogx-operator -n opendatahub-ogx-system
+            kubectl logs -l app.kubernetes.io/name=opendatahub-ogx-operator -n opendatahub-ogx-system --tail=100
+            kubectl get events -n opendatahub-ogx-system --sort-by='.lastTimestamp'
+            exit 1
+          fi
+
+      - name: Run ogx-module e2e tests
+        run: |
+          make test-ogx-module-e2e
+
+      - name: Set test results
+        id: test-results
+        if: always()
+        run: |
+          if [ "${{ job.status }}" == "success" ]; then
+            echo "success=true" >> $GITHUB_OUTPUT
+            echo "summary=OGX module E2E tests passed successfully" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+            echo "summary=OGX module E2E tests failed - check logs for details" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get logs
+        if: ${{ always() }}
+        run: |
+          kubectl -n opendatahub-ogx-system get all -o yaml > module-all.log
+          kubectl -n opendatahub-ogx-system logs deployment.apps/opendatahub-ogx-operator > module-operator.log
+          kubectl -n opendatahub-ogx-system logs deployment.apps/opendatahub-ogx-operator --previous > module-operator-previous.log 2>/dev/null || true
+          kubectl -n opendatahub-ogx-system logs deployment.apps/ogx-k8s-operator-controller-manager > root-operator.log 2>/dev/null || true
+          kubectl -n opendatahub-ogx-system describe all > module-all-describe.log
+          kubectl -n opendatahub-ogx-system describe events > module-events.log
+          kubectl get ogxs -o yaml > ogxs.log
+          kubectl get ogxservers --all-namespaces -o yaml > ogxservers.log 2>/dev/null || true
+          echo "=== Module Operator Pod Status ===" > module-debug.log
+          kubectl -n opendatahub-ogx-system get pods -o wide >> module-debug.log 2>&1
+          echo "=== Module Operator Pod Describe ===" >> module-debug.log
+          kubectl -n opendatahub-ogx-system describe pods -l app.kubernetes.io/name=opendatahub-ogx-operator >> module-debug.log 2>&1
+          echo "=== Node Memory Pressure ===" >> module-debug.log
+          kubectl describe nodes | grep -A5 "MemoryPressure\|memory\|OOMKill" >> module-debug.log 2>&1
+          echo "=== Module Operator Events ===" >> module-debug.log
+          kubectl -n opendatahub-ogx-system get events --sort-by='.lastTimestamp' >> module-debug.log 2>&1
+
+      - name: Upload all logs to artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ogx-module-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            *.log
+          retention-days: 1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,13 @@ linters:
           - funlen
           - staticcheck
           - prealloc
+      - path: '^ogx-module/tests/'
+        linters:
+          - errcheck
+          - dupl
+          - funlen
+          - staticcheck
+          - prealloc
       - path: zz_generated
         linters:
           - lll

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ ENVTEST_K8S_VERSION = 1.31.0
 IMG_TAG ?= latest
 IMG ?= $(IMAGE_TAG_BASE):$(IMG_TAG)
 OGX_MODULE_IMG ?= quay.io/opendatahub/odh-ogx-module-operator:odh-stable
+# Optional runtime override for the root OGX operator image deployed by ogx-module.
+OGX_K8S_OPERATOR_IMG ?=
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -148,6 +150,10 @@ test: manifests generate fmt vet envtest ## Run tests. Use TEST_PKGS and TEST_FL
 test-e2e: ## Run e2e tests
 	./hack/deploy-quickstart.sh # Deploy Ollama for e2e tests
 	go test -v ./tests/e2e/ -run ^TestE2E -v ${E2E_TEST_FLAGS}
+
+.PHONY: test-ogx-module-e2e
+test-ogx-module-e2e: ## Run ogx-module e2e tests. Requires a cluster with the module operator already deployed.
+	cd ogx-module && go test -count=1 -v ./tests/e2e/ -run ^TestE2E ${E2E_TEST_FLAGS}
 
 GOLANGCI_LINT_TIMEOUT ?= 5m0s
 .PHONY: lint
@@ -323,6 +329,9 @@ deploy-openshift: manifests kustomize ## Deploy controller to an OpenShift clust
 ogx-module-deploy: kustomize ## Deploy the ogx-module operator from its default bundle.
 	@echo "RELATED_IMAGE_ODH_OGX_MODULE_OPERATOR_IMAGE=${OGX_MODULE_IMG}" > ogx-module/config/overlays/odh/params.env
 	$(KUSTOMIZE) build ogx-module/config/overlays/odh | kubectl apply -f -
+	@if [ -n "$(OGX_K8S_OPERATOR_IMG)" ]; then \
+		kubectl -n opendatahub-ogx-system set env deployment/opendatahub-ogx-operator RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE=$(OGX_K8S_OPERATOR_IMG); \
+	fi
 
 .PHONY: ogx-module-undeploy
 ogx-module-undeploy: kustomize ## Undeploy the ogx-module operator from the current cluster.

--- a/ogx-module/README.md
+++ b/ogx-module/README.md
@@ -217,6 +217,25 @@ Instead:
 6. OGX status reflects provisioning, readiness, degradation, and releases
 ```
 
+## Running e2e tests
+
+The module e2e suite lives in `tests/e2e/` and follows the same layout as the standalone operator suite: validation, creation, then deletion.
+
+It expects the module operator to already be running in the cluster. From the repository root:
+
+```bash
+make ogx-module-deploy OGX_MODULE_IMG=<module-image> OGX_K8S_OPERATOR_IMG=<root-operator-image>
+make test-ogx-module-e2e
+```
+
+The suite:
+
+1. Validates the `OGX` CRD and module operator deployment.
+2. Creates `default-ogx` and waits for the root `ogx-k8s-operator` deployment and status conditions to become ready.
+3. Sets `managementState: Removed`, verifies the root operator is cleaned up, then deletes the `OGX` CR.
+
+On vanilla Kubernetes the tests create a self-signed `ogx-k8s-operator-webhook-cert` secret so the root operator pod can start without OpenShift service-serving-cert injection.
+
 ## Directory layout
 
 ```text
@@ -227,5 +246,6 @@ ogx-module/
   config/
   docs/
   pkg/apis/v1alpha1/
+  tests/e2e/
   tests/scripts/
 ```

--- a/ogx-module/docs/index.md
+++ b/ogx-module/docs/index.md
@@ -12,5 +12,6 @@ Current scope:
 - dedicated manager entrypoint: `[cmd/ogx-module/main.go](../cmd/ogx-module/main.go)`
 - initial ODH-facing `OGX` API: `[pkg/apis/v1alpha1](../pkg/apis/v1alpha1)`
 - placeholder config tree for module packaging: `[config](../config)`
+- e2e suite for the module operator: `[tests/e2e](../tests/e2e)`
 
 Later tasks add the reconciler, deployer, and vendorable manifests.

--- a/ogx-module/go.mod
+++ b/ogx-module/go.mod
@@ -3,8 +3,10 @@ module github.com/ogx-ai/ogx-k8s-operator/ogx-module
 go 1.25.8
 
 require (
+	github.com/distribution/reference v0.6.0
 	github.com/opendatahub-io/odh-platform-utilities v0.0.0-20260506180717-e15e712db78d
 	github.com/spf13/viper v1.21.0
+	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.2
 	k8s.io/apiextensions-apiserver v0.35.2
@@ -25,7 +27,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect

--- a/ogx-module/tests/e2e/creation_test.go
+++ b/ogx-module/tests/e2e/creation_test.go
@@ -1,0 +1,145 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"testing"
+
+	platformv1alpha1 "github.com/ogx-ai/ogx-k8s-operator/ogx-module/pkg/apis/v1alpha1"
+	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func runCreationTests(t *testing.T) *platformv1alpha1.OGX {
+	t.Helper()
+	if TestOpts.SkipCreation {
+		t.Skip("Skipping creation test suite")
+	}
+
+	var instance *platformv1alpha1.OGX
+
+	t.Run("should create OGX", func(t *testing.T) {
+		instance = testCreateOGX(t)
+	})
+
+	requireOGX := func(t *testing.T) {
+		t.Helper()
+		if instance == nil {
+			t.Skip("Skipping: OGX creation failed")
+		}
+	}
+
+	t.Run("should add the OGX finalizer", func(t *testing.T) {
+		requireOGX(t)
+		updated := getOGX(t)
+		require.True(t, containsFinalizer(updated, ogxFinalizer), "OGX should have finalizer %s", ogxFinalizer)
+	})
+
+	t.Run("should deploy the root OGX operator with a ready status", func(t *testing.T) {
+		requireOGX(t)
+		testRootOperatorDeployment(t)
+	})
+
+	t.Run("should establish the OGXServer CRD", func(t *testing.T) {
+		requireOGX(t)
+		err := validateCRD(TestEnv.Client, TestEnv.Ctx, ogxServerCRDName)
+		requireNoErrorWithDebugging(t, err, "OGXServer CRD should be established")
+	})
+
+	t.Run("should report ready status conditions", func(t *testing.T) {
+		requireOGX(t)
+		testOGXReadyStatus(t)
+	})
+
+	t.Run("should report OpenDataHub distribution status", func(t *testing.T) {
+		requireOGX(t)
+		updated := getOGX(t)
+		require.Equal(t, "OpenDataHub", updated.Status.Distribution.Name, "Distribution name should match the module platform")
+		require.NotEmpty(t, updated.Status.Distribution.Version, "Distribution version should be populated")
+	})
+
+	t.Run("should apply root operator image override from the module operator", func(t *testing.T) {
+		requireOGX(t)
+		testRootOperatorImageOverride(t)
+	})
+
+	return instance
+}
+
+func testCreateOGX(t *testing.T) *platformv1alpha1.OGX {
+	t.Helper()
+
+	ensureWebhookCertSecret(t, TestOpts.OperatorNS)
+
+	instance := newManagedOGX()
+	t.Logf("Creating OGX %s", instance.Name)
+
+	err := TestEnv.Client.Create(TestEnv.Ctx, instance)
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		require.NoError(t, err)
+	}
+
+	return getOGX(t)
+}
+
+func testRootOperatorDeployment(t *testing.T) {
+	t.Helper()
+
+	err := EnsureResourceReady(t, TestEnv, schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "Deployment",
+	}, rootOperatorDeploymentName, TestOpts.OperatorNS, ResourceReadyTimeout, isDeploymentReady)
+	requireNoErrorWithDebugging(t, err, "Root OGX operator deployment should become ready")
+
+	requireDeploymentReady(t, rootOperatorDeploymentName, TestOpts.OperatorNS)
+}
+
+func testOGXReadyStatus(t *testing.T) {
+	t.Helper()
+
+	err := waitForOGXCondition(t, string(common.ConditionTypeProvisioningSucceeded), metav1.ConditionTrue, ResourceReadyTimeout)
+	requireNoErrorWithDebugging(t, err, "OGX ProvisioningSucceeded should become True")
+
+	err = waitForOGXCondition(t, conditionRootOperatorReady, metav1.ConditionTrue, ResourceReadyTimeout)
+	requireNoErrorWithDebugging(t, err, "OGX RootOperatorReady should become True")
+
+	err = waitForOGXCondition(t, conditionRootWebhookReady, metav1.ConditionTrue, ResourceReadyTimeout)
+	requireNoErrorWithDebugging(t, err, "OGX RootWebhookReady should become True")
+
+	err = waitForOGXCondition(t, string(common.ConditionTypeReady), metav1.ConditionTrue, ResourceReadyTimeout)
+	requireNoErrorWithDebugging(t, err, "OGX Ready should become True")
+
+	updated := getOGX(t)
+	require.Equal(t, common.PhaseReady, updated.Status.Phase, "OGX phase should be Ready")
+}
+
+func testRootOperatorImageOverride(t *testing.T) {
+	t.Helper()
+
+	moduleDeployment := &appsv1.Deployment{}
+	err := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
+		Namespace: TestOpts.OperatorNS,
+		Name:      moduleDeploymentName,
+	}, moduleDeployment)
+	require.NoError(t, err)
+
+	overrideImage := envValue(moduleDeployment, relatedImageOperatorEnv)
+	if overrideImage == "" {
+		t.Skip("Skipping image override check because RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE is unset")
+	}
+
+	rootDeployment := &appsv1.Deployment{}
+	err = TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
+		Namespace: TestOpts.OperatorNS,
+		Name:      rootOperatorDeploymentName,
+	}, rootDeployment)
+	require.NoError(t, err)
+	require.NotEmpty(t, rootDeployment.Spec.Template.Spec.Containers, "Root operator deployment should have containers")
+	require.Equal(t, overrideImage, rootDeployment.Spec.Template.Spec.Containers[0].Image,
+		"Root operator image should match the module operator override")
+}

--- a/ogx-module/tests/e2e/deletion_test.go
+++ b/ogx-module/tests/e2e/deletion_test.go
@@ -1,0 +1,91 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	platformv1alpha1 "github.com/ogx-ai/ogx-k8s-operator/ogx-module/pkg/apis/v1alpha1"
+	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func runDeletionTests(t *testing.T, instance *platformv1alpha1.OGX) {
+	t.Helper()
+
+	t.Run("should remove root operator resources when managementState is Removed", func(t *testing.T) {
+		testManagementStateRemoved(t, instance)
+	})
+
+	t.Run("should delete OGX CR after resources are removed", func(t *testing.T) {
+		latest := getOGX(t)
+		err := TestEnv.Client.Delete(TestEnv.Ctx, latest)
+		if err != nil && !k8serrors.IsNotFound(err) {
+			require.NoError(t, err)
+		}
+
+		err = EnsureResourceDeleted(t, TestEnv, schema.GroupVersionKind{
+			Group:   platformv1alpha1.GroupVersion.Group,
+			Version: platformv1alpha1.GroupVersion.Version,
+			Kind:    platformv1alpha1.OGXKind,
+		}, instance.Name, "", ResourceReadyTimeout)
+		requireNoErrorWithDebugging(t, err, "OGX CR should be deleted")
+
+		podList := &corev1.PodList{}
+		err = TestEnv.Client.List(TestEnv.Ctx, podList,
+			client.InNamespace(TestOpts.OperatorNS),
+			client.MatchingLabels{"app.kubernetes.io/name": "ogx-k8s-operator"})
+		require.NoError(t, err)
+		require.Empty(t, podList.Items, "Found orphaned root operator pods")
+	})
+}
+
+func testManagementStateRemoved(t *testing.T, instance *platformv1alpha1.OGX) {
+	t.Helper()
+
+	err := wait.PollUntilContextTimeout(TestEnv.Ctx, time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		latest := &platformv1alpha1.OGX{}
+		if getErr := TestEnv.Client.Get(ctx, client.ObjectKey{Name: instance.Name}, latest); getErr != nil {
+			return false, getErr
+		}
+		latest.Spec.ManagementState = common.Removed
+		if updateErr := TestEnv.Client.Update(ctx, latest); updateErr != nil {
+			if k8serrors.IsConflict(updateErr) {
+				return false, nil
+			}
+			return false, updateErr
+		}
+		return true, nil
+	})
+	require.NoError(t, err, "Failed to set OGX managementState to Removed")
+
+	err = EnsureResourceDeleted(t, TestEnv, schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "Deployment",
+	}, rootOperatorDeploymentName, TestOpts.OperatorNS, ResourceReadyTimeout)
+	requireNoErrorWithDebugging(t, err, "Root operator deployment should be deleted when OGX is Removed")
+
+	err = waitForOGXCondition(t, string(common.ConditionTypeProvisioningSucceeded), metav1.ConditionFalse, ResourceReadyTimeout)
+	requireNoErrorWithDebugging(t, err, "OGX ProvisioningSucceeded should become False after Removed")
+
+	err = wait.PollUntilContextTimeout(TestEnv.Ctx, pollInterval, ResourceReadyTimeout, true, func(ctx context.Context) (bool, error) {
+		latest := &platformv1alpha1.OGX{}
+		if getErr := TestEnv.Client.Get(ctx, client.ObjectKey{Name: instance.Name}, latest); getErr != nil {
+			return false, getErr
+		}
+		return !containsFinalizer(latest, ogxFinalizer), nil
+	})
+	requireNoErrorWithDebugging(t, err, "OGX finalizer should be cleared after Removed cleanup")
+
+	updated := getOGX(t)
+	require.Equal(t, common.PhaseNotReady, updated.Status.Phase, "OGX phase should be NotReady after Removed")
+	require.False(t, containsFinalizer(updated, ogxFinalizer), "OGX finalizer should be cleared after Removed cleanup")
+}

--- a/ogx-module/tests/e2e/e2e_test.go
+++ b/ogx-module/tests/e2e/e2e_test.go
@@ -1,0 +1,37 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"testing"
+
+	platformv1alpha1 "github.com/ogx-ai/ogx-k8s-operator/ogx-module/pkg/apis/v1alpha1"
+)
+
+func TestE2E(t *testing.T) {
+	registerSchemes()
+
+	t.Run("validation", TestValidationSuite)
+
+	var creationFailed bool
+	var createdOGX *platformv1alpha1.OGX
+
+	t.Run("creation-deletion", func(t *testing.T) {
+		t.Run("creation", func(t *testing.T) {
+			createdOGX = runCreationTests(t)
+			creationFailed = t.Failed()
+		})
+
+		if creationFailed || TestOpts.SkipDeletion || createdOGX == nil {
+			if TestOpts.SkipDeletion {
+				t.Log("Skipping deletion tests (SkipDeletion=true)")
+			} else {
+				t.Log("Skipping deletion tests due to creation test failures")
+			}
+			return
+		}
+
+		t.Run("deletion", func(t *testing.T) {
+			runDeletionTests(t, createdOGX)
+		})
+	})
+}

--- a/ogx-module/tests/e2e/setup_test.go
+++ b/ogx-module/tests/e2e/setup_test.go
@@ -1,0 +1,25 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"os"
+	"testing"
+)
+
+var (
+	TestEnv *TestEnvironment
+)
+
+func TestMain(m *testing.M) {
+	var err error
+	TestEnv, err = SetupTestEnv()
+	if err != nil {
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	CleanupTestEnv(TestEnv)
+
+	os.Exit(code)
+}

--- a/ogx-module/tests/e2e/test_options.go
+++ b/ogx-module/tests/e2e/test_options.go
@@ -1,0 +1,33 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"fmt"
+)
+
+// TestOptions defines the configuration for running module e2e tests.
+type TestOptions struct {
+	SkipValidation bool
+	SkipCreation   bool
+	SkipDeletion   bool
+	OperatorNS     string
+}
+
+// TestOpts is the global test options instance.
+var TestOpts = NewTestOptions()
+
+// NewTestOptions creates a new TestOptions instance with default values.
+func NewTestOptions() *TestOptions {
+	return &TestOptions{
+		SkipValidation: false,
+		SkipCreation:   false,
+		SkipDeletion:   false,
+		OperatorNS:     moduleOperatorNS,
+	}
+}
+
+// String returns a string representation of the test options.
+func (o *TestOptions) String() string {
+	return fmt.Sprintf("SkipValidation: %v, SkipCreation: %v, SkipDeletion: %v, OperatorNS: %s",
+		o.SkipValidation, o.SkipCreation, o.SkipDeletion, o.OperatorNS)
+}

--- a/ogx-module/tests/e2e/test_utils.go
+++ b/ogx-module/tests/e2e/test_utils.go
@@ -1,0 +1,483 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"math/big"
+	"testing"
+	"time"
+
+	platformv1alpha1 "github.com/ogx-ai/ogx-k8s-operator/ogx-module/pkg/apis/v1alpha1"
+	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+const (
+	moduleOperatorNS           = "opendatahub-ogx-system"
+	moduleDeploymentName       = "opendatahub-ogx-operator"
+	rootOperatorDeploymentName = "ogx-k8s-operator-controller-manager"
+	rootWebhookSecretName      = "ogx-k8s-operator-webhook-cert"
+	ogxCRDName                 = "ogxs.components.platform.opendatahub.io"
+	ogxServerCRDName           = "ogxservers.ogx.io"
+	ogxFinalizer               = "components.platform.opendatahub.io/ogx-finalizer"
+	conditionRootOperatorReady = "RootOperatorReady"
+	conditionRootWebhookReady  = "RootWebhookReady"
+	relatedImageOperatorEnv    = "RELATED_IMAGE_ODH_OGX_K8S_OPERATOR_IMAGE"
+	pollInterval               = 10 * time.Second
+	generalRetryInterval       = 5 * time.Second
+	ResourceReadyTimeout       = 5 * time.Minute
+)
+
+var (
+	Scheme = runtime.NewScheme()
+)
+
+// TestEnvironment holds the test environment configuration.
+type TestEnvironment struct {
+	Client client.Client
+	Ctx    context.Context //nolint:containedctx // Context is used for test environment
+}
+
+// SetupTestEnv sets up the test environment.
+func SetupTestEnv() (*TestEnvironment, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	cl, err := client.New(cfg, client.Options{Scheme: Scheme})
+	if err != nil {
+		return nil, err
+	}
+
+	return &TestEnvironment{
+		Client: cl,
+		Ctx:    context.TODO(),
+	}, nil
+}
+
+// CleanupTestEnv cleans up the test environment.
+func CleanupTestEnv(_ *TestEnvironment) {
+}
+
+func validateCRD(c client.Client, ctx context.Context, crdName string) error {
+	crd := &apiextv1.CustomResourceDefinition{}
+	obj := client.ObjectKey{Name: crdName}
+
+	return wait.PollUntilContextTimeout(ctx, generalRetryInterval, ResourceReadyTimeout, true, func(ctx context.Context) (bool, error) {
+		err := c.Get(ctx, obj, crd)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			log.Printf("Failed to get CRD %s", crdName)
+			return false, err
+		}
+
+		for _, condition := range crd.Status.Conditions {
+			if condition.Type == apiextv1.Established && condition.Status == apiextv1.ConditionTrue {
+				return true, nil
+			}
+		}
+		log.Printf("Error to get CRD %s condition's matching", crdName)
+		return false, nil
+	})
+}
+
+// GetDeployment gets a deployment by name and namespace.
+func GetDeployment(cl client.Client, ctx context.Context, name, namespace string) (*appsv1.Deployment, error) {
+	deployment := &appsv1.Deployment{}
+	err := cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, deployment)
+	return deployment, err
+}
+
+// EnsureResourceReady polls until the resource is ready.
+func EnsureResourceReady(
+	t *testing.T,
+	testenv *TestEnvironment,
+	gvk schema.GroupVersionKind,
+	name, namespace string,
+	timeout time.Duration,
+	isReady func(*unstructured.Unstructured) bool,
+) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(testenv.Ctx, timeout)
+	defer cancel()
+	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		err := testenv.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return isReady(obj), nil
+	})
+}
+
+// EnsureResourceDeleted polls until the resource is deleted.
+func EnsureResourceDeleted(t *testing.T, testenv *TestEnvironment, gvk schema.GroupVersionKind, name, namespace string, timeout time.Duration) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(testenv.Ctx, timeout)
+	defer cancel()
+	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		err := testenv.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj)
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+func isDeploymentReady(u *unstructured.Unstructured) bool {
+	generation, _, _ := unstructured.NestedInt64(u.Object, "metadata", "generation")
+	observedGeneration, foundObserved, err := unstructured.NestedInt64(u.Object, "status", "observedGeneration")
+	if err != nil || (foundObserved && observedGeneration < generation) {
+		return false
+	}
+
+	expected := int64(1)
+	if replicas, found, specErr := unstructured.NestedInt64(u.Object, "spec", "replicas"); specErr == nil && found && replicas > 0 {
+		expected = replicas
+	}
+
+	readyReplicas, foundReady, err := unstructured.NestedInt64(u.Object, "status", "readyReplicas")
+	if !foundReady || err != nil {
+		return false
+	}
+	availableReplicas, foundAvailable, err := unstructured.NestedInt64(u.Object, "status", "availableReplicas")
+	if !foundAvailable || err != nil {
+		return false
+	}
+
+	return readyReplicas >= expected && availableReplicas >= expected
+}
+
+func requireDeploymentReady(t *testing.T, name, namespace string) *appsv1.Deployment {
+	t.Helper()
+
+	deployment, err := GetDeployment(TestEnv.Client, TestEnv.Ctx, name, namespace)
+	require.NoError(t, err, "Deployment %s/%s not found", namespace, name)
+
+	expected := int32(1)
+	if deployment.Spec.Replicas != nil {
+		expected = *deployment.Spec.Replicas
+	}
+
+	require.GreaterOrEqual(t, deployment.Status.ObservedGeneration, deployment.Generation,
+		"Deployment %s/%s has not observed the latest generation", namespace, name)
+	require.GreaterOrEqual(t, deployment.Status.ReadyReplicas, expected,
+		"Deployment %s/%s ReadyReplicas=%d want >= %d", namespace, name, deployment.Status.ReadyReplicas, expected)
+	require.GreaterOrEqual(t, deployment.Status.AvailableReplicas, expected,
+		"Deployment %s/%s AvailableReplicas=%d want >= %d", namespace, name, deployment.Status.AvailableReplicas, expected)
+	require.GreaterOrEqual(t, deployment.Status.UpdatedReplicas, expected,
+		"Deployment %s/%s UpdatedReplicas=%d want >= %d", namespace, name, deployment.Status.UpdatedReplicas, expected)
+	require.True(t, isDeploymentAvailable(deployment),
+		"Deployment %s/%s should have Available=True", namespace, name)
+
+	requireDeploymentPodsReady(t, deployment)
+	return deployment
+}
+
+func isDeploymentAvailable(deployment *appsv1.Deployment) bool {
+	for _, condition := range deployment.Status.Conditions {
+		if condition.Type == appsv1.DeploymentAvailable {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func requireDeploymentPodsReady(t *testing.T, deployment *appsv1.Deployment) {
+	t.Helper()
+
+	podList := &corev1.PodList{}
+	err := TestEnv.Client.List(TestEnv.Ctx, podList,
+		client.InNamespace(deployment.Namespace),
+		client.MatchingLabels(deployment.Spec.Selector.MatchLabels))
+	require.NoError(t, err, "Failed to list pods for deployment %s/%s", deployment.Namespace, deployment.Name)
+	require.NotEmpty(t, podList.Items, "No pods found for deployment %s/%s", deployment.Namespace, deployment.Name)
+
+	for _, pod := range podList.Items {
+		require.Equal(t, corev1.PodRunning, pod.Status.Phase, "Pod %s is not running", pod.Name)
+		require.True(t, isPodReady(&pod), "Pod %s is not ready", pod.Name)
+		for _, cs := range pod.Status.ContainerStatuses {
+			require.True(t, cs.Ready, "Container %s in pod %s is not ready", cs.Name, pod.Name)
+		}
+	}
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func registerSchemes() {
+	schemes := []func(*runtime.Scheme) error{
+		clientgoscheme.AddToScheme,
+		apiextv1.AddToScheme,
+		platformv1alpha1.AddToScheme,
+	}
+
+	for _, schemeFn := range schemes {
+		utilruntime.Must(schemeFn(Scheme))
+	}
+}
+
+func newManagedOGX() *platformv1alpha1.OGX {
+	return &platformv1alpha1.OGX{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: platformv1alpha1.GroupVersion.String(),
+			Kind:       platformv1alpha1.OGXKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: platformv1alpha1.OGXInstanceName,
+		},
+		Spec: platformv1alpha1.OGXSpec{
+			ManagementSpec: common.ManagementSpec{ManagementState: common.Managed},
+		},
+	}
+}
+
+func getOGX(t *testing.T) *platformv1alpha1.OGX {
+	t.Helper()
+	instance := &platformv1alpha1.OGX{}
+	err := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{Name: platformv1alpha1.OGXInstanceName}, instance)
+	require.NoError(t, err, "OGX CR %s should exist", platformv1alpha1.OGXInstanceName)
+	return instance
+}
+
+func waitForOGXCondition(t *testing.T, conditionType string, want metav1.ConditionStatus, timeout time.Duration) error {
+	t.Helper()
+	return wait.PollUntilContextTimeout(TestEnv.Ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		instance := &platformv1alpha1.OGX{}
+		err := TestEnv.Client.Get(ctx, client.ObjectKey{Name: platformv1alpha1.OGXInstanceName}, instance)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		for _, condition := range instance.Status.Conditions {
+			if condition.Type == conditionType {
+				t.Logf("OGX condition %s=%s reason=%s message=%s phase=%s",
+					condition.Type, condition.Status, condition.Reason, condition.Message, instance.Status.Phase)
+				return condition.Status == want, nil
+			}
+		}
+
+		t.Logf("OGX condition %s not present yet; phase=%s conditions=%+v", conditionType, instance.Status.Phase, instance.Status.Conditions)
+		return false, nil
+	})
+}
+
+func envValue(deployment *appsv1.Deployment, name string) string {
+	for i := range deployment.Spec.Template.Spec.Containers {
+		container := deployment.Spec.Template.Spec.Containers[i]
+		if container.Name != "manager" {
+			continue
+		}
+		for _, env := range container.Env {
+			if env.Name == name {
+				return env.Value
+			}
+		}
+	}
+	return ""
+}
+
+func ensureWebhookCertSecret(t *testing.T, namespace string) {
+	t.Helper()
+
+	certPEM, keyPEM, err := generateSelfSignedCert(namespace)
+	require.NoError(t, err, "failed to generate webhook certificate")
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rootWebhookSecretName,
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certPEM,
+			corev1.TLSPrivateKeyKey: keyPEM,
+		},
+	}
+
+	err = TestEnv.Client.Create(TestEnv.Ctx, secret)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		require.NoError(t, err, "failed to create webhook certificate secret")
+	}
+}
+
+func generateSelfSignedCert(namespace string) ([]byte, []byte, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "ogx-k8s-operator-webhook-service",
+		},
+		DNSNames: []string{
+			"ogx-k8s-operator-webhook-service",
+			"ogx-k8s-operator-webhook-service." + namespace,
+			"ogx-k8s-operator-webhook-service." + namespace + ".svc",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return certPEM, keyPEM, nil
+}
+
+func requireNoErrorWithDebugging(t *testing.T, err error, msg string) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+
+	t.Logf("ERROR OCCURRED: %s - %v", msg, err)
+	logOGXStatus(t)
+	logNamespaceEvents(t, TestOpts.OperatorNS)
+	logPodDetails(t, TestOpts.OperatorNS)
+	logDeploymentSpec(t, TestOpts.OperatorNS, moduleDeploymentName)
+	logDeploymentSpec(t, TestOpts.OperatorNS, rootOperatorDeploymentName)
+
+	require.NoError(t, err, msg)
+}
+
+func logOGXStatus(t *testing.T) {
+	t.Helper()
+
+	instance := &platformv1alpha1.OGX{}
+	err := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{Name: platformv1alpha1.OGXInstanceName}, instance)
+	if err != nil {
+		t.Logf("Error getting OGX: %v", err)
+		return
+	}
+
+	t.Logf("OGX status:")
+	t.Logf("  Phase: %s", instance.Status.Phase)
+	t.Logf("  Generation: %d", instance.Generation)
+	t.Logf("  ObservedGeneration: %d", instance.Status.ObservedGeneration)
+	t.Logf("  Distribution: %+v", instance.Status.Distribution)
+	t.Logf("  Conditions: %+v", instance.Status.Conditions)
+}
+
+func logNamespaceEvents(t *testing.T, namespace string) {
+	t.Helper()
+
+	eventList := &corev1.EventList{}
+	err := TestEnv.Client.List(TestEnv.Ctx, eventList, client.InNamespace(namespace))
+	if err != nil {
+		t.Logf("Error getting events: %v", err)
+		return
+	}
+
+	maxEvents := 25
+	if len(eventList.Items) > maxEvents {
+		t.Logf("Showing first %d events (of %d total):", maxEvents, len(eventList.Items))
+		eventList.Items = eventList.Items[:maxEvents]
+	} else {
+		t.Logf("Found %d events in namespace %s:", len(eventList.Items), namespace)
+	}
+
+	for _, event := range eventList.Items {
+		t.Logf("  %s: %s (%s) - %s",
+			event.LastTimestamp.Format("15:04:05"),
+			event.Reason,
+			event.Type,
+			event.Message)
+	}
+}
+
+func logPodDetails(t *testing.T, namespace string) {
+	t.Helper()
+
+	podList := &corev1.PodList{}
+	err := TestEnv.Client.List(TestEnv.Ctx, podList, client.InNamespace(namespace))
+	if err != nil {
+		t.Logf("Failed to list pods: %v", err)
+		return
+	}
+
+	t.Logf("Found %d pods in namespace %s:", len(podList.Items), namespace)
+	for _, pod := range podList.Items {
+		t.Logf("Pod: %s, Phase: %s", pod.Name, pod.Status.Phase)
+		for _, cs := range pod.Status.ContainerStatuses {
+			t.Logf("  Container %s: Ready=%v, RestartCount=%d", cs.Name, cs.Ready, cs.RestartCount)
+			if cs.State.Waiting != nil {
+				t.Logf("    Waiting: %s - %s", cs.State.Waiting.Reason, cs.State.Waiting.Message)
+			}
+			if cs.State.Terminated != nil {
+				t.Logf("    Terminated: %s - %s", cs.State.Terminated.Reason, cs.State.Terminated.Message)
+			}
+		}
+	}
+}
+
+func logDeploymentSpec(t *testing.T, namespace, name string) {
+	t.Helper()
+
+	deployment := &appsv1.Deployment{}
+	err := TestEnv.Client.Get(TestEnv.Ctx, types.NamespacedName{Name: name, Namespace: namespace}, deployment)
+	if err != nil {
+		t.Logf("Failed to get deployment %s: %v", name, err)
+		return
+	}
+
+	t.Logf("Deployment %s spec:", name)
+	t.Logf("  Replicas: %d", *deployment.Spec.Replicas)
+	t.Logf("  ReadyReplicas: %d", deployment.Status.ReadyReplicas)
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		t.Logf("  Container: %s image=%s", container.Name, container.Image)
+	}
+}

--- a/ogx-module/tests/e2e/validation_test.go
+++ b/ogx-module/tests/e2e/validation_test.go
@@ -1,0 +1,40 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"testing"
+
+	platformv1alpha1 "github.com/ogx-ai/ogx-k8s-operator/ogx-module/pkg/apis/v1alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidationSuite(t *testing.T) {
+	if TestOpts.SkipValidation {
+		t.Skip("Skipping validation test suite")
+	}
+
+	t.Run("should validate OGX CRD", func(t *testing.T) {
+		err := validateCRD(TestEnv.Client, TestEnv.Ctx, ogxCRDName)
+		require.NoErrorf(t, err, "error in validating CRD: %s", ogxCRDName)
+	})
+
+	t.Run("should validate module operator deployment status", func(t *testing.T) {
+		requireDeploymentReady(t, moduleDeploymentName, TestOpts.OperatorNS)
+	})
+
+	t.Run("should reject OGX resources that are not named default-ogx", func(t *testing.T) {
+		invalid := newManagedOGX()
+		invalid.Name = "not-default-ogx"
+		err := TestEnv.Client.Create(TestEnv.Ctx, invalid)
+		require.Error(t, err, "OGX resources must be named %s", platformv1alpha1.OGXInstanceName)
+	})
+}
+
+func containsFinalizer(instance *platformv1alpha1.OGX, value string) bool {
+	for _, item := range instance.GetFinalizers() {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}

--- a/ogx-module/tests/scripts/README.md
+++ b/ogx-module/tests/scripts/README.md
@@ -1,1 +1,3 @@
 This directory is reserved for module-specific test scripts.
+
+Go end-to-end tests for the module operator live in [`../e2e`](../e2e). Run them from the repository root with `make test-ogx-module-e2e` after deploying the module operator.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR introduces e2e test suite for `ogx-module` operator
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Run
https://github.com/opendatahub-io/ogx-k8s-operator/actions/runs/32274118279/job/96137329850?pr=151 
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive end-to-end testing for OGX module creation, validation, readiness, and deletion.
  * Added automated pull request checks that build, deploy, test, and collect diagnostics from a Kubernetes environment.
  * Added options to run tests selectively and override the operator image.

* **Documentation**
  * Documented prerequisites, commands, test workflows, cleanup, and certificate handling.

* **Chores**
  * Auto-merge now requires successful OGX module end-to-end tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->